### PR TITLE
Fix/backend attack (#392)

### DIFF
--- a/infrastructure/Dockerfile.n8n
+++ b/infrastructure/Dockerfile.n8n
@@ -1,15 +1,13 @@
 # Usamos la imagen oficial 'latest'.
-# Al no necesitar Python, esta imagen es perfecta: ligera, segura y mantenida por n8n.
 FROM n8nio/n8n:latest
 
 USER root
 
-# Instalamos solo las librerías de Node.js que usas en tus scripts (Function Nodes)
-# y la extensión de LangChain.
-# El flag '--omit=dev' ahorra espacio y memoria al no bajar dependencias de desarrollo.
+# Instalamos estrictamente las librerías permitidas en NODE_FUNCTION_ALLOW_EXTERNAL.
+# Se eliminó la instalación manual de LangChain para reducir deuda técnica, 
+# ya que n8n ahora soporta IA nativamente.
 RUN npm install -g jsonwebtoken pdf-parse && \
     mkdir -p /home/node/.n8n/custom && \
-    npm install --prefix /home/node/.n8n/custom @n8n/n8n-nodes-langchain@latest --omit=dev && \
     npm cache clean --force
 
 # Volvemos al usuario seguro 'node' para la ejecución

--- a/infrastructure/docker-compose.yml
+++ b/infrastructure/docker-compose.yml
@@ -13,14 +13,13 @@ services:
     env_file:
       - .env
     environment:
-      - N8N_LOG_LEVEL=info                          # o debug para troubleshooting
-      - N8N_LOG_OUTPUT=console,file                 # escribe tanto en stdout como en archivo
+      - N8N_LOG_LEVEL=info
+      - N8N_LOG_OUTPUT=console,file
       - N8N_LOG_FILE_LOCATION=/home/node/.n8n/logs/n8n.log
-      - N8N_LOG_FILE_SIZE_MAX=50                    # MB por archivo
-      - N8N_LOG_FILE_COUNT_MAX=10                   # cantidad de archivos retenidos (rotación)
-      # Execution / retention
+      - N8N_LOG_FILE_SIZE_MAX=50
+      - N8N_LOG_FILE_COUNT_MAX=10
       - EXECUTIONS_DATA_PRUNE=true
-      - EXECUTIONS_DATA_MAX_AGE=336                 # horas (336 = 14 días). Ajusta según necesidad
+      - EXECUTIONS_DATA_MAX_AGE=336
       - EXECUTIONS_DATA_SAVE_ON_ERROR=all
       - EXECUTIONS_DATA_SAVE_ON_SUCCESS=all
       - N8N_EXPRESS_TRUST_PROXY=loopback,linklocal,unicast
@@ -36,7 +35,7 @@ services:
       - N8N_EDITOR_BASE_URL=https://${SUBDOMAIN}.${DOMAIN_NAME}
       - N8N_FORCE_HTTPS=true
       - DB_TYPE=postgresdb
-      - DB_POSTGRESDB_HOST=postgres
+      - DB_POSTGRESDB_HOST=postgres # Se resuelve por DNS interno de Docker
       - DB_POSTGRESDB_PORT=${port_db}
       - DB_POSTGRESDB_DATABASE=${n8n_db}
       - DB_POSTGRESDB_USER=${n8n_user}
@@ -47,10 +46,8 @@ services:
       - JWT_SECRET=${JWT_SECRET}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_API_KEY_IMMS=${OPENAI_API_KEY_IMMS}
-      # - N8N_WORKER_COUNT=2
       - N8N_GIT_NODE_DISABLE_BARE_REPOS=true
-      - SERVICES_TIMEOUT=300   # 60
-      #- NODE_OPTIONS=--max-old-space-size=1024 --require /home/node/.n8n/custom/init-blob.js
+      - SERVICES_TIMEOUT=300
       - INTERNAL_SECRET=${INTERNAL_SECRET}
       - N8N_BLOCK_ENV_VARS_INCLUDE=INTERNAL_SECRET
       - N8N_BLOCK_EXTERNAL_STORAGE_FUNCTIONS=true
@@ -59,12 +56,10 @@ services:
     depends_on:
       - postgres
     volumes:
-      # Cambiamos el volumen nombrado (vacio) por la ruta real de tus datos
-      - /opt/n8n/data/n8n_data:/home/node/.n8n  # <--- ASEGÚRATE QUE ESTA RUTA ES LA CORRECTA
+      - /opt/n8n/data/n8n_data:/home/node/.n8n
       - ${PROJECT_ROOT}/local-files:/files
       - ${PROJECT_ROOT}/custom:/home/node/.n8n/custom
       - ${LOGS_PATH}:/home/node/.n8n/logs
-      # Rutas de sistema (Mantenidas por necesidad de Plesk)
       - /var/lib/psa/dumps:/var/lib/psa/dumps
       - ./.env:/home/node/.env
     networks:
@@ -90,8 +85,9 @@ services:
     volumes:
       - /opt/n8n/data/postgres_db_backup:/var/lib/postgresql/data
       - ./postgres/initdb:/docker-entrypoint-initdb.d
-    ports:
-      - "${port_db}:${port_db}"
+    # ELIMINADO: ports: - "${port_db}:${port_db}" (Seguridad Crítica)
+    expose:
+      - "${port_db}" # Permite tráfico solo dentro de n8n_enterprise_net
     networks:
       - n8n_enterprise_net
     logging:
@@ -106,8 +102,9 @@ services:
       dockerfile: Dockerfile
     container_name: n8n-jwt-service
     restart: always
-    ports:
-      - "${port_jwt}:${port_jwt}"
+    # ELIMINADO: ports expuestos al mundo.
+    expose:
+      - "${port_jwt}"
     env_file:
       - .env
     environment:
@@ -128,8 +125,9 @@ services:
       dockerfile: Dockerfile
     container_name: n8n-scraper-service
     restart: always
-    ports:
-      - "${port_scraper}:${port_scraper}"
+    # ELIMINADO: ports expuestos al mundo.
+    expose:
+      - "${port_scraper}"
     environment:
       - NODE_ENV=production
       - USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36"
@@ -137,15 +135,14 @@ services:
       - PORT=3001
     networks:
       - n8n_enterprise_net
-    shm_size: '1g' # Establecer a 1 GB. (La mitad de tu RAM física es lo ideal)
+    # OPTIMIZACIÓN DE RECURSOS PARA EVITAR OOM KILL EN VPS DE 2 VCPU
+    shm_size: '512m' # Reducido temporalmente. Si usa Puppeteer, 512m es suficiente para concurrencia baja.
     deploy:
       resources:
         limits:
-          memory: 1200m # Limita su uso total a 1.2 GB (RAM + SWAP).
-          # Si no tienes Swap activado, usa 700m como límite duro.
-          # Dado que tienes Swap, podemos darle más techo aquí.
+          memory: 800m # Techo más conservador para evitar colisionar con Plesk y n8n
         reservations:
-          memory: 500m
+          memory: 300m
     logging:
       driver: "json-file"
       options:
@@ -164,7 +161,7 @@ services:
       - FIEL_CER_PATH=/app/certs/csd.cer
       - FIEL_KEY_PATH=/app/certs/csd.key
     volumes:
-      # Montaje de volumen en modo Read-Only (:ro). 
+      # Montaje de volumen en modo Read-Only (:ro).
       # El contenedor puede leer las llaves, pero NUNCA modificarlas o borrarlas.
       - ./certs/fea:/app/certs:ro
     networks:

--- a/microservices/scraper-service/index.js
+++ b/microservices/scraper-service/index.js
@@ -41,19 +41,6 @@ function isSafeUrl(inputUrl) {
     }
 }
 
-// NAVEGACIÓN
-try {
-    if (!isSafeUrl(finalUrl)) {
-        throw new Error("URL rechazada por políticas de seguridad (SSRF prevention).");
-    }
-
-    // USAR finalUrl AQUÍ (Variable que viene del objeto URL validado)
-    await page.goto(finalUrl, { waitUntil: 'domcontentloaded', timeout: 60000 });
-
-} catch (e) {
-    console.log(`[WARN] Goto: ${e.message}`);
-}
-
 app.post('/scrape', async (req, res) => {
     let browser = null;
     try {


### PR DESCRIPTION
* # fix(infra): secure backend attack surface and optimize memory allocations

## Executive Summary
This pull request addresses critical security vulnerabilities and resource contention issues within the n8n infrastructure stack. It eliminates public port bindings for internal backend microservices (PostgreSQL, JWT, Scraper) enforcing communication strictly through the internal Docker bridge network. Additionally, memory reservations and limits are recalibrated to prevent Out-Of-Memory (OOM) kills on the scraper service, and obsolete community node installations are removed from the Dockerfile to optimize the image size and build time.

## Checklist de Cambios
- [x] Removed `ports` exposure for `postgres`, `jwt-service`, and `scraper-service`.
- [x] Adjusted hard and soft memory limits for `scraper-service` to align with the VPS hardware constraints.
- [x] Refactored `Dockerfile.n8n` to remove redundant LangChain community package installation.
- [x] Added `expose` directive to microservices for explicit internal network documentation.

## Detalles Técnicos Profundos
1. **Network Security:** By removing the `ports` mapping (`0.0.0.0:PORT`) and replacing it with `expose`, we guarantee that Plesk's firewall and the public internet cannot reach the DB, JWT, or Scraper directly. `n8n` will still resolve and communicate with these services using Docker's internal DNS (e.g., `http://postgres:5432` or `http://jwt-service:3000`).
2. **Resource Optimization:** The `scraper-service` was allocating `1200m` of memory. In a 2 vCPU environment shared with Plesk, pgvector, and n8n, this aggressive reservation triggers the Linux OOM Killer, causing the `Restarting (1)` loop. The hard limit has been adjusted down, and concurrency should be managed via environment variables.
3. **Dockerfile Technical Debt:** The `@n8n/n8n-nodes-langchain` node is deprecated for recent n8n versions, which now include the "Advanced AI" nodes natively. Removing this saves disk space, RAM, and reduces startup time.

## Protocolo de Pruebas
1. Deploy the updated stack: `docker compose up -d --build`.
2. Verify network isolation: Attempt to connect to the PostgreSQL database from an external client using the VPS public IP. The connection **must** time out.
3. Verify internal connectivity: Execute `docker exec -it n8n-enterprise-core ping postgres` to ensure DNS resolution inside the bridge network.
4. Monitor scraper stability: Run `docker stats` and `docker logs -f n8n-scraper-service` to ensure the container remains stable (`Up`) without entering a restart loop.

## Checklist Senior
- [x] Does this change align with a CloudFree and secure-by-default architecture?
- [x] Are we avoiding technical debt by relying on native features instead of obsolete dependencies?
- [x] Is the environment variable injection properly isolated for internal communication?

* # fix(infra): secure backend attack surface and optimize memory allocations

## Executive Summary
This pull request addresses critical security vulnerabilities and resource contention issues within the n8n infrastructure stack. It eliminates public port bindings for internal backend microservices (PostgreSQL, JWT, Scraper) enforcing communication strictly through the internal Docker bridge network. Additionally, memory reservations and limits are recalibrated to prevent Out-Of-Memory (OOM) kills on the scraper service, and obsolete community node installations are removed from the Dockerfile to optimize the image size and build time.

## Checklist de Cambios
- [x] Removed `ports` exposure for `postgres`, `jwt-service`, and `scraper-service`.
- [x] Adjusted hard and soft memory limits for `scraper-service` to align with the VPS hardware constraints.
- [x] Refactored `Dockerfile.n8n` to remove redundant LangChain community package installation.
- [x] Added `expose` directive to microservices for explicit internal network documentation.

## Detalles Técnicos Profundos
1. **Network Security:** By removing the `ports` mapping (`0.0.0.0:PORT`) and replacing it with `expose`, we guarantee that Plesk's firewall and the public internet cannot reach the DB, JWT, or Scraper directly. `n8n` will still resolve and communicate with these services using Docker's internal DNS (e.g., `http://postgres:5432` or `http://jwt-service:3000`).
2. **Resource Optimization:** The `scraper-service` was allocating `1200m` of memory. In a 2 vCPU environment shared with Plesk, pgvector, and n8n, this aggressive reservation triggers the Linux OOM Killer, causing the `Restarting (1)` loop. The hard limit has been adjusted down, and concurrency should be managed via environment variables.
3. **Dockerfile Technical Debt:** The `@n8n/n8n-nodes-langchain` node is deprecated for recent n8n versions, which now include the "Advanced AI" nodes natively. Removing this saves disk space, RAM, and reduces startup time.

## Protocolo de Pruebas
1. Deploy the updated stack: `docker compose up -d --build`.
2. Verify network isolation: Attempt to connect to the PostgreSQL database from an external client using the VPS public IP. The connection **must** time out.
3. Verify internal connectivity: Execute `docker exec -it n8n-enterprise-core ping postgres` to ensure DNS resolution inside the bridge network.
4. Monitor scraper stability: Run `docker stats` and `docker logs -f n8n-scraper-service` to ensure the container remains stable (`Up`) without entering a restart loop.

## Checklist Senior
- [x] Does this change align with a CloudFree and secure-by-default architecture?
- [x] Are we avoiding technical debt by relying on native features instead of obsolete dependencies?
- [x] Is the environment variable injection properly isolated for internal communication?