### PR TITLE
Feat(admin): UPP (Unidad de Producción Pecuaria) CRUD — scaffold, lis…

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/docs/DATABASE_SCHEMA.md
+++ b/hosting3m-workspace/projects/agro-erp/docs/DATABASE_SCHEMA.md
@@ -1,44 +1,46 @@
 # 🗄️ Database Architecture & Meta-CRUD Schema
 
 ## 📝 Resumen Ejecutivo
-Este documento define la estructura de persistencia para el módulo Agro ERP. El sistema utiliza PostgreSQL 15+ con un modelo de datos híbrido: relaciones estrictas para la integridad Multi-Tenant y campos `JSONB` para absorber la variabilidad de la telemetría agrícola y médica[cite: 1, 2]. Todo el acceso a datos está orquestado por el router dinámico `crud_models` vía n8n[cite: 2, 3].
+Este documento define la estructura de persistencia centralizada para el módulo Agro ERP dentro de la Hosting3M Automation Suite. El sistema utiliza PostgreSQL 15+ con un modelo de datos híbrido: relaciones estrictas para la integridad y control de acceso (RBAC), y columnas `JSONB` (`metadata`, `medicines_json`) para absorber la variabilidad de la telemetría agrícola, datos de padrones oficiales y registros médicos. Todo el acceso a datos está orquestado por el router dinámico `crud_models` vía n8n (Meta-CRUD v3).
 
-## 🏗️ Diccionario de Datos (Módulo Cattle)
+## 🏗️ Diccionario de Datos (Módulo Agro/Cattle)
 
-### 1. Entidades Principales (Core)
+### 1. Entidades Principales (Core & Multi-Tenant)
 
-*   **`cattle_tenants` (Inquilinos/Empresas)**
-    *   **Descripción:** Gestiona el aislamiento Multi-Tenant del sistema.
-    *   **Campos Clave:** `id` (UUID), `tax_id`, `name`, `org_type` (GANADERO, UNION, GOBIERNO).
-    *   **Meta-CRUD Roles:** SELECT, INSERT, UPDATE, DELETE, GETONE, GETALL (Roles: ADMIN, EDITOR).
+* **`companys` (Inquilinos / UPPs / Ranchos Maestros)**
+    * **Descripción:** Tabla maestra que gestiona el aislamiento Multi-Tenant y Multi-Dominio de todo el ecosistema (Hotelería, Ganadería, etc.).
+    * **Mapeo Agropecuario:** El `company_name` funge como el Nombre del Rancho, y el campo `industry` se clasifica como `"GANADERIA"`.
+    * **Soporte Híbrido (JSONB):** Incorpora la columna `metadata` para inyectar datos específicos de la vertical sin sobre-normalizar la base de datos relacional. Aquí reside la parametrización de SINIIGA: `clave_upp`, `folio_holograma`, `curp`, `rfc`, `superficie_ha`, y `fecha_alta`.
+    * **Meta-CRUD Roles:** SELECT, INSERT, UPDATE, DELETE, GETONE, GETALL. (Operaciones restringidas a ADMIN y EDITOR).
 
-*   **`cattle_livestock` (Inventario de Biomasa)**
-    *   **Descripción:** Registro maestro de animales. Soporta múltiples especies (BOVINO, BUFALO, BORREGO) y modelos de negocio[cite: 4].
-    *   **Campos Clave:** `id` (UUID), `tenant_id` (FK), `rfid_siniiga` (Unique), `electronic_rfid` (Unique), `numero_fuego`, `current_status`.
-    *   **Hardware de Trazabilidad:** Optimizado para lectura de Bolo Ruminal (Cápsula Cerámica) como identificador principal en campo por su alta durabilidad.
-    *   **Check Constraints:** Valida estatus operativos críticos (ACTIVO, PREÑADA, VACÍA, FINALIZADO)[cite: 4].
+* **`cattle_livestock` (Inventario de Biomasa)**
+    * **Descripción:** Registro maestro de animales. Soporta múltiples especies biológicas y modelos de negocio transaccionales (CRIA, ENGORDA).
+    * **Campos Clave:** `id` (UUID), `tenant_id` (FK a `companys`), `rfid_siniiga` (Unique), `electronic_rfid` (Unique), `numero_fuego`, `current_status`.
+    * **Hardware de Trazabilidad:** Optimizado para lectura de Bolo Ruminal (Cápsula Cerámica) como identificador primario en campo para mitigar la pérdida física de aretes plásticos.
+    * **Check Constraints:** Valida de forma nativa estatus operativos críticos a nivel de motor (ACTIVO, PREÑADA, VACÍA, FINALIZADO).
 
 ### 2. Entidades Transaccionales (Logs & Telemetry)
 
-*   **`cattle_health_logs` (Eventos Sanitarios)**
-    *   **Descripción:** Registra intervenciones médicas y diagnósticos.
-    *   **Campos Clave:** `event_type`, `event_date`, `medicines_json` (JSONB para flexibilidad de tratamientos)[cite: 1, 4].
-    *   **Delete Rule:** `ON DELETE CASCADE` asociado al `livestock_id`.
+* **`cattle_health_logs` (Eventos Sanitarios)**
+    * **Descripción:** Registra intervenciones médicas, palpaciones y diagnósticos reproductivos.
+    * **Campos Clave:** `event_type`, `event_date`, `medicines_json` (JSONB para flexibilidad de dosificación de tratamientos).
+    * **Delete Rule:** `ON DELETE CASCADE` asociado al `livestock_id`.
 
-*   **`cattle_weight_logs` (Control de Biomasa)**
-    *   **Descripción:** Registro histórico de pesajes.
-    *   **Campos Clave:** `weight_kg`, `log_date`, `source_device`.
-    *   **Triggers:** Ejecuta `update_current_weight()` `AFTER INSERT` para recalcular el peso actual de la biomasa automáticamente.
+* **`cattle_weight_logs` (Control de Biomasa)**
+    * **Descripción:** Registro histórico inmutable de pesajes para el cálculo de la Ganancia Diaria de Peso (ADG).
+    * **Campos Clave:** `weight_kg`, `log_date`, `source_device`.
 
-*   **`cattle_expenses` (OPEX / Gasto Operativo)**
-    *   **Descripción:** Registra costos directos vinculados a un animal o al tenant general.
-    *   **Campos Clave:** `amount`, `category`, `health_event_id` (Opcional, FK a `cattle_health_logs`).
+* **`cattle_expenses` (OPEX / Gasto Operativo)**
+    * **Descripción:** Registra costos directos vinculados a un animal específico o al Rancho en general para el cálculo de rentabilidad por kilo.
+    * **Campos Clave:** `amount`, `category`, `health_event_id` (Opcional, FK a `cattle_health_logs`).
 
-*   **`cattle_task_evidence` (Trazabilidad de Tareas)**
-    *   **Descripción:** Almacena evidencia multimedia de tareas ejecutadas en campo.
-    *   **Campos Clave:** `task_name`, `evidence_url`, `status` (PENDIENTE, COMPLETADO, RECHAZADO).
+* **`cattle_task_evidence` (Trazabilidad de Auditoría)**
+    * **Descripción:** Almacena evidencia multimedia de tareas ejecutadas en campo (fotografías/videos).
+    * **Campos Clave:** `task_name`, `evidence_url`, `status` (PENDIENTE, COMPLETADO, RECHAZADO).
 
-## ⚙️ Meta-CRUD Routing Configuration (n8n)
-La tabla `crud_models` delega las operaciones al API Gateway, eliminando la necesidad de endpoints rígidos[cite: 1, 2]. 
-*   **Aislamiento de Inyección:** Entidades como `cattle_weight_logs` habilitan el rol `IOT` para la ingesta de telemetría sin requerir privilegios `ADMIN`.
-*   **Joins Dinámicos:** Configurados a nivel de base de datos. Por ejemplo, `cattle_expenses` ejecuta joins automáticos con `cattle_livestock` (`numero_fuego`, `business_model`) y `cattle_health_logs` para consolidación financiera instantánea.
+## ⚙️ Meta-CRUD Routing Configuration (n8n v3)
+La tabla `crud_models` delega todas las validaciones de entrada, RBAC y operaciones al API Gateway, garantizando una arquitectura de *Zero-Hallucination* al no exponer endpoints rígidos.
+
+* **Validación Estricta de Payload (`schema_json`):** Bloquea inyecciones de parámetros no deseados. Campos dinámicos como `metadata` en la tabla `companys` están explícitamente habilitados (whitelisted) en la propiedad `allowed_fields` para permitir el tráfico de objetos anidados desde el cliente Angular.
+* **Aislamiento de Inyección IOT:** Entidades como `cattle_weight_logs` habilitan el rol secundario `IOT` para la ingesta automatizada de telemetría (básculas/lectores) sin requerir privilegios de `ADMIN`.
+* **Joins Declarativos Multidireccionales:** Configurados a nivel del motor en n8n. Entidades como `cattle_expenses` ejecutan *joins* automáticos con `cattle_livestock` y `cattle_health_logs` para retornar objetos consolidados al cliente sin carga computacional en el frontend.

--- a/hosting3m-workspace/projects/agro-erp/src/app/core/models/company.model.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/core/models/company.model.ts
@@ -12,4 +12,15 @@ export interface Company {
     last_contact?: string | Date;
     notes?: string;
     is_default: boolean;
+    business_type?: 'AGRICULTURE' | 'LIVESTOCK' | 'ADMIN';
+    metadata?: {
+        nombre_productor?: string;
+        clave_upp?: string;
+        folio_holograma?: string;
+        curp?: string;
+        rfc?: string;
+        superficie_ha?: number;
+        fecha_alta?: string;
+        [key: string]: any;
+    };
 }

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/tenant-list/tenant-list.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/tenant-list/tenant-list.component.html
@@ -1,1 +1,105 @@
-<p>tenant-list works!</p>
+<div class="container-fluid p-3 p-md-4 animate__animated animate__fadeIn">
+
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="d-flex align-items-center gap-3">
+            <div class="d-none d-md-block">
+                <span class="bg-green-lt p-2 rounded-3"><i class="ti ti-building-warehouse fs-2"></i></span>
+            </div>
+            <div>
+                <h2 class="page-title mb-0">Unidades de Producción Pecuaria</h2>
+                <div class="text-muted small mt-1">Ranchos y padrones SINIIGA a los que tienes acceso</div>
+            </div>
+        </div>
+        <div>
+            <button class="btn btn-primary shadow-sm" (click)="openModal()">
+                <i class="ti ti-square-rounded-plus me-2"></i>
+                <span class="d-none d-sm-inline">Nueva UPP</span>
+                <span class="d-inline d-sm-none">Nueva</span>
+            </button>
+        </div>
+    </div>
+
+    <div class="row g-2 mb-3 align-items-center">
+        <div class="col-12 col-md-8">
+            <div class="input-group">
+                <span class="input-group-text bg-white border-end-0">
+                    <i class="ti ti-search text-muted"></i>
+                </span>
+                <input type="text" class="form-control border-start-0"
+                    placeholder="Buscar por nombre del rancho..."
+                    [ngModel]="searchQuery()" (ngModelChange)="searchQuery.set($event)">
+            </div>
+        </div>
+        <div class="col-12 col-md-4 text-muted small text-end">
+            {{ filteredTenants().length }} / {{ tenants().length }} UPP
+        </div>
+    </div>
+
+    <div class="row row-cards">
+        @for (tenant of filteredTenants(); track tenant.id_company) {
+        <div class="col-12 col-md-6 col-xl-4">
+            <div class="card shadow-sm border-0 h-100 hover-shadow-lg transition-all">
+                <div class="card-body d-flex align-items-center p-3">
+
+                    <span class="avatar avatar-md me-3 text-uppercase fw-bold rounded shadow-sm"
+                        [class.bg-green-lt]="tenant.role === 'ADMIN'" [class.bg-blue-lt]="tenant.role !== 'ADMIN'">
+                        {{ (tenant.company_name || '?').charAt(0) }}
+                    </span>
+
+                    <div class="flex-fill overflow-hidden">
+                        <div class="font-weight-medium fs-4 text-truncate mb-1">
+                            {{ tenant.company_name }}
+                        </div>
+
+                        <div class="mb-1">
+                            <span class="badge" [class.bg-green-lt]="tenant.role === 'ADMIN'"
+                                [class.bg-blue-lt]="tenant.role !== 'ADMIN'">
+                                {{ tenant.role === 'ADMIN' ? 'Administrador' : tenant.role }}
+                            </span>
+                            @if (tenant.industry) {
+                            <span class="badge bg-orange-lt ms-1">{{ tenant.industry }}</span>
+                            }
+                        </div>
+
+                        <div class="text-muted fs-5 mt-1 text-truncate">
+                            <i class="ti ti-hash me-2"></i> ID {{ tenant.id_company }}
+                        </div>
+                    </div>
+
+                    <div class="ms-3 d-flex flex-column gap-1">
+                        @if (canEdit(tenant)) {
+                        <button class="btn btn-icon btn-outline-secondary btn-sm" (click)="openModal(tenant)"
+                            [disabled]="isLoadingDetail()" title="Editar UPP">
+                            <i class="ti ti-edit"></i>
+                        </button>
+                        } @else {
+                        <button class="btn btn-icon btn-outline-secondary btn-sm" (click)="openModal(tenant)"
+                            [disabled]="isLoadingDetail()" title="Ver UPP">
+                            <i class="ti ti-eye"></i>
+                        </button>
+                        }
+                    </div>
+
+                </div>
+                <div class="card-progress-bottom"
+                    [style.background-color]="tenant.role === 'ADMIN' ? '#2fb344' : '#4299e1'"></div>
+            </div>
+        </div>
+        } @empty {
+        <div class="col-12 text-center py-5">
+            <div class="empty-state">
+                <div class="empty-img"><i class="ti ti-building-off fs-1 text-muted"></i></div>
+                <p class="empty-title fs-3">No tienes UPP registradas</p>
+                <p class="empty-subtitle text-muted">Da de alta tu primer rancho para comenzar a operar.</p>
+                <button class="btn btn-primary mt-3" (click)="openModal()">
+                    <i class="ti ti-square-rounded-plus me-2"></i> Nueva UPP
+                </button>
+            </div>
+        </div>
+        }
+    </div>
+</div>
+
+<app-upp-form-modal [isOpen]="isModalOpen()" [selectedUpp]="selectedUpp()" [isReadonly]="isReadOnlyMode()"
+    [(uppData)]="currentUppData" (onClose)="closeModal()" (onSave)="saveUpp()">
+</app-upp-form-modal>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/tenant-list/tenant-list.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/tenant-list/tenant-list.component.ts
@@ -1,11 +1,121 @@
-import { Component } from '@angular/core';
+import { Component, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { lastValueFrom } from 'rxjs';
+import { AdminService } from '@features/admin/services/admin.service';
+import { UppFormModalComponent } from '../upp-form-modal/upp-form-modal.component';
+import { AuthService, TenantService, TenantContext } from 'core-auth';
 
 @Component({
   selector: 'app-tenant-list',
-  imports: [],
+  standalone: true,
+  imports: [CommonModule, FormsModule, UppFormModalComponent],
   templateUrl: './tenant-list.component.html',
   styleUrl: './tenant-list.component.scss',
 })
 export class TenantListComponent {
+  public adminService = inject(AdminService);
+  public tenantService = inject(TenantService);
+  private authService = inject(AuthService);
 
+  // Solo las UPP a las que el usuario tiene acceso (resueltas en el login multi-tenant)
+  tenants = this.tenantService.availableTenants;
+
+  searchQuery = signal<string>('');
+
+  filteredTenants = computed(() => {
+    const q = this.searchQuery().toLowerCase();
+    return this.tenants().filter(t => !q || t.company_name?.toLowerCase().includes(q));
+  });
+
+  isModalOpen = signal<boolean>(false);
+  isLoadingDetail = signal<boolean>(false);
+  isReadOnlyMode = signal<boolean>(false);
+  selectedUpp = signal<any>(null);
+  currentUppData = signal<any>({});
+
+  canEdit(tenant: TenantContext): boolean {
+    return tenant.role === 'ADMIN';
+  }
+
+  async openModal(tenant: TenantContext | null = null) {
+    if (tenant) {
+      this.isLoadingDetail.set(true);
+      this.isReadOnlyMode.set(!this.canEdit(tenant));
+      try {
+        const res = await lastValueFrom(this.adminService.getCompanyById(tenant.id_company));
+        const fullCompany = res.data?.[0] ?? tenant;
+        this.selectedUpp.set(fullCompany);
+        this.currentUppData.set({ ...fullCompany, metadata: { ...fullCompany.metadata } });
+        this.isModalOpen.set(true);
+      } catch (error) {
+        console.error('[Agro-ERP] Error al cargar detalle de UPP:', error);
+        alert('❌ No se pudo cargar la información de la UPP.');
+      } finally {
+        this.isLoadingDetail.set(false);
+      }
+    } else {
+      this.isReadOnlyMode.set(false);
+      this.selectedUpp.set(null);
+      this.currentUppData.set(this.getEmptyUpp());
+      this.isModalOpen.set(true);
+    }
+  }
+
+  closeModal() {
+    this.isModalOpen.set(false);
+    this.selectedUpp.set(null);
+  }
+
+  async saveUpp() {
+    if (this.isReadOnlyMode()) return;
+
+    const data = this.currentUppData();
+    const operation: 'insert' | 'update' = this.selectedUpp() ? 'update' : 'insert';
+
+    if (!data.company_name) {
+      alert('⚠️ El Nombre del Rancho es obligatorio.');
+      return;
+    }
+
+    try {
+      const res = await lastValueFrom(
+        this.adminService.saveCompany(data, operation, this.selectedUpp()?.id_company)
+      );
+
+      if (operation === 'insert') {
+        const created = res.data?.[0];
+        const email = this.authService.currentUser()?.email;
+
+        if (created && email) {
+          await lastValueFrom(
+            this.adminService.saveUserCompany(email, created.id_company, 'ADMIN', true, 'insert')
+          );
+
+          const newTenant: TenantContext = {
+            id_company: created.id_company,
+            company_name: created.company_name,
+            role: 'ADMIN',
+            industry: created.industry || 'GANADERIA',
+            business_type: 'LIVESTOCK'
+          };
+          this.tenantService.setAvailableTenants([...this.tenantService.availableTenants(), newTenant]);
+        }
+      }
+
+      alert(operation === 'insert' ? '✅ UPP registrada correctamente' : '✅ UPP actualizada correctamente');
+      this.closeModal();
+    } catch (error) {
+      console.error('[Agro-ERP] Error al guardar la UPP:', error);
+      alert('❌ Error al guardar el registro en la base de datos.');
+    }
+  }
+
+  private getEmptyUpp() {
+    return {
+      company_name: '',
+      industry: 'GANADERIA',
+      metadata: {}
+    };
+  }
 }

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/upp-form-modal/upp-form-modal.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/upp-form-modal/upp-form-modal.component.html
@@ -1,0 +1,100 @@
+@if (isOpen()) {
+<div class="modal-backdrop fade show"></div>
+<div class="modal modal-blur fade show d-block" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content shadow-lg border-0">
+            <div class="modal-header bg-dark text-white">
+                <h5 class="modal-title">
+                    <i class="ti ti-building-warehouse me-2"></i>
+                    @if (isReadonly()) {
+                    Detalle de la UPP
+                    } @else {
+                    {{ selectedUpp() ? 'Actualizar Unidad de Producción Pecuaria' : 'Alta de Nueva UPP' }}
+                    }
+                </h5>
+                <button type="button" class="btn-close btn-close-white" (click)="onClose.emit()"></button>
+            </div>
+            <div class="modal-body p-4">
+                <div class="mb-3">
+                    <label class="form-label fw-bold">Nombre del Rancho <span class="text-danger">*</span></label>
+                    <input type="text" class="form-control shadow-sm" [disabled]="isReadonly()"
+                        [ngModel]="uppData().company_name" (ngModelChange)="updateField('company_name', $event)"
+                        placeholder="Ej. Rancho San Isidro">
+                </div>
+
+                <hr class="my-4">
+                <h6 class="text-muted text-uppercase fw-bold mb-3">Padrón SINIIGA</h6>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Nombre del Productor</label>
+                        <input type="text" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="uppData().metadata?.nombre_productor"
+                            (ngModelChange)="updateMetadataField('nombre_productor', $event)"
+                            placeholder="Ej. Juan Carlos Hermida">
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Clave UPP</label>
+                        <input type="text" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="uppData().metadata?.clave_upp"
+                            (ngModelChange)="updateMetadataField('clave_upp', $event)"
+                            placeholder="Ej. 23-001-0001">
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Folio Holograma SINIIGA</label>
+                        <input type="text" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="uppData().metadata?.folio_holograma"
+                            (ngModelChange)="updateMetadataField('folio_holograma', $event)"
+                            placeholder="Ej. A0000001">
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Fecha de Alta SINIIGA</label>
+                        <input type="date" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="uppData().metadata?.fecha_alta"
+                            (ngModelChange)="updateMetadataField('fecha_alta', $event)">
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">CURP</label>
+                        <input type="text" class="form-control shadow-sm text-uppercase" maxlength="18"
+                            [disabled]="isReadonly()"
+                            [ngModel]="uppData().metadata?.curp"
+                            (ngModelChange)="updateMetadataField('curp', $event)"
+                            placeholder="18 caracteres">
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">RFC</label>
+                        <input type="text" class="form-control shadow-sm text-uppercase" [disabled]="isReadonly()"
+                            [ngModel]="uppData().metadata?.rfc"
+                            (ngModelChange)="updateMetadataField('rfc', $event)"
+                            placeholder="Ej. HEPJ800101ABC">
+                    </div>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label fw-bold">Superficie en Hectáreas</label>
+                    <input type="number" step="0.01" class="form-control shadow-sm" [disabled]="isReadonly()"
+                        [ngModel]="uppData().metadata?.superficie_ha"
+                        (ngModelChange)="updateMetadataField('superficie_ha', $event)"
+                        placeholder="Ej. 120.50">
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary px-4 shadow-sm" (click)="onClose.emit()">
+                    {{ isReadonly() ? 'Cerrar' : 'Cancelar' }}
+                </button>
+                @if (!isReadonly()) {
+                <button class="btn btn-success px-4 shadow-sm" (click)="onSave.emit()">
+                    <i class="ti ti-device-floppy me-2"></i> Guardar Cambios
+                </button>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/upp-form-modal/upp-form-modal.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/upp-form-modal/upp-form-modal.component.ts
@@ -1,0 +1,30 @@
+import { CommonModule } from '@angular/common';
+import { Component, input, model, output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-upp-form-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './upp-form-modal.component.html',
+})
+export class UppFormModalComponent {
+  isOpen = input.required<boolean>();
+  selectedUpp = input<any>(null);
+  isReadonly = input<boolean>(false);
+  uppData = model.required<any>();
+
+  onClose = output<void>();
+  onSave = output<void>();
+
+  updateField(key: string, value: any) {
+    this.uppData.update(current => ({ ...current, [key]: value }));
+  }
+
+  updateMetadataField(key: string, value: any) {
+    this.uppData.update(current => ({
+      ...current,
+      metadata: { ...current.metadata, [key]: value },
+    }));
+  }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
@@ -85,6 +85,34 @@ export class AdminService {
     });
   }
 
+  /* Obtiene el detalle completo de una UPP (incluye metadata JSONB de SINIIGA) */
+  public getCompanyById(idCompany: number) {
+    const payload = {
+      entity: 'companys',
+      table_name: 'companys',
+      operation: 'getone',
+      action: 'getone',
+      filters: { id_company: idCompany }
+    };
+    return this.http.post<ApiResponse<Company>>(`${this.apiUrl_crud}/companys`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  /* Alta o actualización de una UPP (Rancho) */
+  public saveCompany(company: Partial<Company>, operation: 'insert' | 'update', idCompany?: number) {
+    const payload = {
+      entity: 'companys',
+      table_name: 'companys',
+      operation,
+      id_company: idCompany,
+      fields: company
+    };
+    return this.http.post<ApiResponse<Company>>(`${this.apiUrl_crud}/companys`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
   /* Users */
   public loadUsers() {
     const currentTenantId = this.tenantService.activeTenantId();

--- a/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.html
@@ -84,21 +84,27 @@
                     </div>
                 </li>
 
+                @if (tenantService.activeTenant()?.role === 'ADMIN') {
                 <li class="nav-item">
-                    <a class="nav-link" routerLink="/admin" routerLinkActive="active" (click)="closeMenu()">
+                    <a class="nav-link" routerLink="/admin/tenants" routerLinkActive="active" (click)="closeMenu()">
                         <span class="nav-link-icon text-muted">
                             <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
                                 viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
                                 <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-                                <path d="M9 7m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" />
-                                <path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
-                                <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-                                <path d="M21 21v-2a4 4 0 0 0 -3 -3.85" />
+                                <path d="M3 21l18 0" />
+                                <path d="M9 8l1 0" />
+                                <path d="M9 12l1 0" />
+                                <path d="M9 16l1 0" />
+                                <path d="M14 8l1 0" />
+                                <path d="M14 12l1 0" />
+                                <path d="M14 16l1 0" />
+                                <path d="M5 21v-16a2 2 0 0 1 2 -2h10a2 2 0 0 1 2 2v16" />
                             </svg>
                         </span>
-                        <span class="nav-link-title">Socios Inversores</span>
+                        <span class="nav-link-title">Unidades de Producción (UPP)</span>
                     </a>
                 </li>
+                }
 
                 @if (tenantService.activeTenant()?.role === 'ADMIN') {
                 <li class="nav-item">


### PR DESCRIPTION
…tado y menú (#521)

* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

---------