### PR TITLE
Feat(livestock): buscador por arete + orden de columnas en el Censo B…

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/src/app/core/services/cattle-api.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/core/services/cattle-api.service.ts
@@ -27,6 +27,8 @@ export class CattleApiService {
         try {
             // 🚀 SOLUCIÓN DEFENSIVA: Mandamos la propiedad de ambas formas (raíz y estructurada)
             // por si el Meta-CRUD de n8n espera la misma anatomía que el 'insert' o un query directo.
+            // Nota: el workflow de n8n para vw_cattle_kpi no aplica ORDER BY dinámico, por eso el
+            // orden se resuelve de forma determinística en el cliente (ver CattleListComponent).
             const payload = {
                 operation: 'getall',
                 tenant_id: Number(currentTenantId),
@@ -34,8 +36,6 @@ export class CattleApiService {
                     tenant_id: Number(currentTenantId)
                 }
             };
-
-            // this.logger.log(`📡 [CattleAPI] Solicitando vw_cattle_kpi para Tenant ID: ${currentTenantId}`, payload);
 
             const res: any = await firstValueFrom(
                 this.http.post<any>(this.apiUrl_crud + '/vw_cattle_kpi', payload)

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/inventory/components/cattle-list/cattle-list.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/inventory/components/cattle-list/cattle-list.component.html
@@ -33,7 +33,9 @@
         <h3 class="card-title text-dark font-weight-bold mb-0">Total de Cabezas: {{ totalHeads() }}</h3>
         <div class="text-muted text-sm">
             <div class="input-icon">
-                <input type="text" class="form-control form-control-rounded" placeholder="Buscar por Arete...">
+                <input type="text" class="form-control form-control-rounded"
+                    placeholder="Buscar por Arete, Fuego o Chip RFID..." [ngModel]="searchQuery()"
+                    (ngModelChange)="searchQuery.set($event)">
                 <span class="input-icon-addon">
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
                         stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round"
@@ -44,18 +46,69 @@
                     </svg>
                 </span>
             </div>
+            @if (searchQuery()) {
+            <div class="small mt-1">{{ filteredCattleList().length }} / {{ totalHeads() }} resultados</div>
+            }
         </div>
     </div>
     <div class="table-responsive">
         <table class="table card-table table-vcenter text-nowrap">
             <thead class="bg-light">
                 <tr>
-                    <th>Arete (RFID)</th>
-                    <th>Socio Dueño</th>
-                    <th>Categoría</th>
-                    <th>Modelo de Negocio</th>
-                    <th class="text-end">Peso Actual</th>
-                    <th>Estatus Actual</th>
+                    <th class="cursor-pointer user-select-none" (click)="toggleSort('rfid_siniiga')">
+                        Arete (RFID)
+                        @if (sortColumn() === 'rfid_siniiga') {
+                        <i class="ti ms-1" [class.ti-sort-ascending]="sortDirection() === 'asc'"
+                            [class.ti-sort-descending]="sortDirection() === 'desc'"></i>
+                        } @else {
+                        <i class="ti ti-arrows-sort ms-1 text-muted opacity-50"></i>
+                        }
+                    </th>
+                    <th class="cursor-pointer user-select-none" (click)="toggleSort('tenant_name')">
+                        Socio Dueño
+                        @if (sortColumn() === 'tenant_name') {
+                        <i class="ti ms-1" [class.ti-sort-ascending]="sortDirection() === 'asc'"
+                            [class.ti-sort-descending]="sortDirection() === 'desc'"></i>
+                        } @else {
+                        <i class="ti ti-arrows-sort ms-1 text-muted opacity-50"></i>
+                        }
+                    </th>
+                    <th class="cursor-pointer user-select-none" (click)="toggleSort('category')">
+                        Categoría
+                        @if (sortColumn() === 'category') {
+                        <i class="ti ms-1" [class.ti-sort-ascending]="sortDirection() === 'asc'"
+                            [class.ti-sort-descending]="sortDirection() === 'desc'"></i>
+                        } @else {
+                        <i class="ti ti-arrows-sort ms-1 text-muted opacity-50"></i>
+                        }
+                    </th>
+                    <th class="cursor-pointer user-select-none" (click)="toggleSort('business_model')">
+                        Modelo de Negocio
+                        @if (sortColumn() === 'business_model') {
+                        <i class="ti ms-1" [class.ti-sort-ascending]="sortDirection() === 'asc'"
+                            [class.ti-sort-descending]="sortDirection() === 'desc'"></i>
+                        } @else {
+                        <i class="ti ti-arrows-sort ms-1 text-muted opacity-50"></i>
+                        }
+                    </th>
+                    <th class="text-end cursor-pointer user-select-none" (click)="toggleSort('current_weight_kg')">
+                        Peso Actual
+                        @if (sortColumn() === 'current_weight_kg') {
+                        <i class="ti ms-1" [class.ti-sort-ascending]="sortDirection() === 'asc'"
+                            [class.ti-sort-descending]="sortDirection() === 'desc'"></i>
+                        } @else {
+                        <i class="ti ti-arrows-sort ms-1 text-muted opacity-50"></i>
+                        }
+                    </th>
+                    <th class="cursor-pointer user-select-none" (click)="toggleSort('current_status')">
+                        Estatus Actual
+                        @if (sortColumn() === 'current_status') {
+                        <i class="ti ms-1" [class.ti-sort-ascending]="sortDirection() === 'asc'"
+                            [class.ti-sort-descending]="sortDirection() === 'desc'"></i>
+                        } @else {
+                        <i class="ti ti-arrows-sort ms-1 text-muted opacity-50"></i>
+                        }
+                    </th>
                     <th class="text-end">Acciones</th>
                 </tr>
             </thead>
@@ -67,7 +120,7 @@
                         <div class="mt-2">Sincronizando con Ledger Criptográfico...</div>
                     </td>
                 </tr>
-                } @else if (cattleList().length === 0) {
+                } @else if (filteredCattleList().length === 0) {
                 <tr>
                     <td colspan="7" class="text-center py-5 text-muted">
                         <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-database-off"
@@ -82,11 +135,14 @@
                             <path d="M20 13.914v-9.914" />
                             <path d="M3 3l18 18" />
                         </svg>
-                        <div class="mt-2">No hay cabezas de ganado registradas en este rancho.</div>
+                        <div class="mt-2">
+                            {{ searchQuery() ? 'Ningún animal coincide con la búsqueda.' : 'No hay cabezas de ganado
+                            registradas en este rancho.' }}
+                        </div>
                     </td>
                 </tr>
                 } @else {
-                @for (animal of cattleList(); track animal.id) {
+                @for (animal of filteredCattleList(); track animal.id) {
                 <tr>
                     <td>
                         <div class="font-monospace font-weight-bold fs-3"

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/inventory/components/cattle-list/cattle-list.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/inventory/components/cattle-list/cattle-list.component.ts
@@ -1,14 +1,17 @@
-import { Component, inject, OnInit, signal } from '@angular/core';
+import { Component, inject, OnInit, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { CattleDetailModalComponent } from '../cattle-detail-modal/cattle-detail-modal.component';
 import { CattleApiService } from '@core/services/cattle-api.service';
 import { TenantService } from 'core-auth';
 import { CattleDataService } from '@core/services/cattle-data.service';
 
+type SortableColumn = 'rfid_siniiga' | 'tenant_name' | 'category' | 'business_model' | 'current_weight_kg' | 'current_status';
+
 @Component({
   selector: 'app-cattle-list',
   standalone: true,
-  imports: [CommonModule, CattleDetailModalComponent],
+  imports: [CommonModule, FormsModule, CattleDetailModalComponent],
   templateUrl: './cattle-list.component.html',
   styleUrl: './cattle-list.component.scss',
 })
@@ -24,6 +27,37 @@ export class CattleListComponent implements OnInit {
 
   // Signals para manejar el estado reactivo
   public totalHeads = signal<number>(0);
+
+  // Búsqueda por arete y orden de columnas (evita que el orden "salte" tras cada guardado,
+  // ya que la vista vw_cattle_kpi no garantiza un orden estable entre lecturas)
+  public searchQuery = signal<string>('');
+  public sortColumn = signal<SortableColumn>('rfid_siniiga');
+  public sortDirection = signal<'asc' | 'desc'>('asc');
+  private readonly numericColumns: SortableColumn[] = ['current_weight_kg'];
+
+  public filteredCattleList = computed(() => {
+    const q = this.searchQuery().trim().toLowerCase();
+    const column = this.sortColumn();
+    const direction = this.sortDirection();
+
+    const source = this.cattleList();
+    const filtered = !q ? source : source.filter(animal =>
+      animal.rfid_siniiga?.toLowerCase().includes(q) ||
+      animal.numero_fuego?.toLowerCase().includes(q) ||
+      animal.electronic_rfid?.toLowerCase().includes(q)
+    );
+
+    return [...filtered].sort((a, b) => {
+      const valueA = a[column];
+      const valueB = b[column];
+
+      const comparison = this.numericColumns.includes(column)
+        ? Number(valueA ?? 0) - Number(valueB ?? 0)
+        : String(valueA ?? '').localeCompare(String(valueB ?? ''), 'es', { sensitivity: 'base' });
+
+      return direction === 'asc' ? comparison : -comparison;
+    });
+  });
 
   // Variables para el Modal
   public isModalOpen = false;
@@ -46,6 +80,15 @@ export class CattleListComponent implements OnInit {
       console.error('Error cargando inventario:', error);
     } finally {
       this.isLoading.set(false);
+    }
+  }
+
+  public toggleSort(column: SortableColumn) {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update(dir => dir === 'asc' ? 'desc' : 'asc');
+    } else {
+      this.sortColumn.set(column);
+      this.sortDirection.set('asc');
     }
   }
 


### PR DESCRIPTION
…iológico (#527)

* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

* fix(build): resolve tsconfig path mappings and ng-packagr compilation crash

- Remove localized 'paths' configuration from projects/ui-chat/tsconfig.lib.json to prevent internal ng-packagr destructuring errors.
- Delegate 'core-auth' module resolution to the workspace root tsconfig.json pointing directly to the dist/ directory.
- Enforce clean architectural boundaries by ensuring libraries consume built artifacts rather than raw source code.

* fix(livestock): shorten "Fecha Brucelosis" label in cattle detail modal

Renamed "Fecha Prueba Brucelosis" to "Fecha Brucelosis" in both the ALTA and EDITAR forms of CattleDetailModalComponent for label consistency.

* feat(livestock): add search-by-tag and client-side column sorting to cattle inventory

- Wire the previously non-functional search input to filter by rfid_siniiga, numero_fuego and electronic_rfid (case-insensitive substring match)
- Add sortable column headers (Arete, Socio Dueño, Categoría, Modelo de Negocio, Peso Actual, Estatus Actual) via toggleSort(), with visual ascending/descending indicators
- Introduce filteredCattleList computed signal that always sorts deterministically before rendering, since vw_cattle_kpi has no stable ORDER BY and row order shifted after every save
- Remove the dead `sort` payload field from CattleApiService.getAllLivestock() — confirmed the n8n Meta-CRUD workflow for vw_cattle_kpi ignores it; ordering is now fully resolved client-side

---------