### PR TITLE
Docs(agro-erp): Registrar auditoría `historico_movimientos` y regla d…

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/CHANGELOG.md
+++ b/hosting3m-workspace/projects/agro-erp/CHANGELOG.md
@@ -3,6 +3,20 @@
 Todos los cambios notables en el proyecto **n8n Enterprise Automation Suite** serán documentados en este archivo.
 El formato se basa en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/), y este proyecto se adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
+## [1.8.1] - 2026-07-08
+
+### 📚 Sincronización de Documentación y Validación de Esquema
+
+Alineación de `DATABASE_SCHEMA.md` y `ARCHITECTURE.md` contra el estado real de producción (VPS), con verificación campo por campo sin discrepancias contra un clon local restaurado el mismo día.
+
+#### 🗄️ Documentación de Base de Datos
+* **Campos y tablas antes indocumentados:** `cattle_livestock.upp_origen`, la tabla de auditoría `historico_movimientos`, la vista `vw_cattle_kpi`, y las tablas `cattle_tenants`, `cattle_task_evidence` y `agriculture_telemetry`.
+* **Modelo Meta-CRUD `salida_ganado` (ID 46):** Documentado en `ARCHITECTURE.md` como el único modelo que invoca una función PL/pgSQL (`sp_procesar_salida_ganado`) en lugar de una tabla física.
+* **Corrección de RBAC:** `cattle_livestock` (el borrado es `ADMIN` exclusivo, no `ADMIN,EDITOR`) y `cattle_tenants` (la lectura está abierta a `EDITOR`, no solo a `ADMIN`).
+
+#### 🔁 Infraestructura de Validación
+* **Pipeline de respaldo extendido:** `backup_postgres_vps_to_local.sh` ahora replica tanto `n8n_db` como `hosting3m_db` diariamente (antes solo `n8n_db`), permitiendo validar la documentación contra un clon local sin necesitar acceso directo al VPS de producción.
+
 ## [1.8.0] - 2026-07-07
 
 ### 🚀 Consolidación del Core Business Logic y Server-Side BI

--- a/hosting3m-workspace/projects/agro-erp/CLAUDE.md
+++ b/hosting3m-workspace/projects/agro-erp/CLAUDE.md
@@ -21,7 +21,11 @@ Debes actuar siempre como mi **Technical Lead auxiliar y Senior Project Manager 
 
 ### 3. Integridad Normativa en Procedimientos Almacenados
 * La venta y salida de animales debe ejecutarse exclusivamente a través de `sp_procesar_salida_ganado`. Esta rutina procesa el bloqueo transaccional (`FOR UPDATE`) y verifica que los campos `tb_test_date` y `br_test_date` no excedan los 60 días.
+* Cada venta exitosa queda auditada en `historico_movimientos` (`tipo_movimiento = VENTA`) y limpia el `upp_origen` del animal. El gateway n8n expone esta rutina como el modelo Meta-CRUD `salida_ganado` (ID 46, únicamente `INSERT`) — nunca como escritura directa a `cattle_livestock`.
 
 ### 4. Stateful Context Injection (Agentes de IA)
 * Los agentes LLM tienen prohibido inferir parámetros de la base de datos (Zero-Hallucination). Cualquier herramienta de escritura o consulta requiere inyección silenciosa del `tenant_id`.
 * Anti-Jailbreak: Cualquier inserción exige un protocolo "Human-in-the-Loop" previo.
+
+### 5. Validación de Esquema contra Réplica Local
+* Antes de proponer cambios de estructura de base de datos, valida contra el clon local de `hosting3m_db` (contenedor `n8n-enterprise-db`), restaurado automáticamente todos los días desde el VPS vía `~/scripts/backup_postgres_vps_to_local.sh`. No asumas el estado de producción sin confirmarlo ahí.

--- a/hosting3m-workspace/projects/agro-erp/README.md
+++ b/hosting3m-workspace/projects/agro-erp/README.md
@@ -19,6 +19,7 @@ Desarrollada como una **Angular 21 SPA** estructurada por dominios (*Feature-Dri
 ### 2. 🧠 Server-Side Business Intelligence (BI) y Meta-CRUD transaccional
 * **Dynamic Gateway:** La función `execute_metacrud_write` orquesta todas las inyecciones de datos (INSERT/UPDATE) desde n8n de forma dinámica, validando permisos contra la tabla `crud_models`.
 * **Reglas Sanitarias Estrictas:** El procedimiento `sp_procesar_salida_ganado` bloquea ventas si el animal no cuenta con pruebas de Tuberculosis o Brucelosis vigentes (menos de 60 días de antigüedad).
+* **Auditoría de Movimientos:** Cada venta, baja o traslado queda registrado de forma inmutable en `historico_movimientos`, preservando el `upp_origen` (rancho/centro de costos) del animal al momento del evento.
 * **Sincronización de Biomasa:** Triggers en base de datos (`update_current_weight`) automatizan la actualización de la biomasa actual del animal cada vez que se registra un pesaje.
 
 ### 3. 🏢 Escalabilidad Multi-Dominio (Context Switcher)


### PR DESCRIPTION
…e validación contra réplica local (#531)

* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

* fix(build): resolve tsconfig path mappings and ng-packagr compilation crash

- Remove localized 'paths' configuration from projects/ui-chat/tsconfig.lib.json to prevent internal ng-packagr destructuring errors.
- Delegate 'core-auth' module resolution to the workspace root tsconfig.json pointing directly to the dist/ directory.
- Enforce clean architectural boundaries by ensuring libraries consume built artifacts rather than raw source code.

* fix(livestock): shorten "Fecha Brucelosis" label in cattle detail modal

Renamed "Fecha Prueba Brucelosis" to "Fecha Brucelosis" in both the ALTA and EDITAR forms of CattleDetailModalComponent for label consistency.

* feat(livestock): add search-by-tag and client-side column sorting to cattle inventory

- Wire the previously non-functional search input to filter by rfid_siniiga, numero_fuego and electronic_rfid (case-insensitive substring match)
- Add sortable column headers (Arete, Socio Dueño, Categoría, Modelo de Negocio, Peso Actual, Estatus Actual) via toggleSort(), with visual ascending/descending indicators
- Introduce filteredCattleList computed signal that always sorts deterministically before rendering, since vw_cattle_kpi has no stable ORDER BY and row order shifted after every save
- Remove the dead `sort` payload field from CattleApiService.getAllLivestock() — confirmed the n8n Meta-CRUD workflow for vw_cattle_kpi ignores it; ordering is now fully resolved client-side

* docs(agro-erp): align v1.8.0 docs with real DB schema and PL/pgSQL engine

- Document upp_origen, historico_movimientos, vw_cattle_kpi and the salida_ganado Meta-CRUD model (wraps sp_procesar_salida_ganado) that were missing from DATABASE_SCHEMA.md and ARCHITECTURE.md
- Fix RBAC bullets that overstated ADMIN-only restrictions on cattle_livestock (delete) and cattle_tenants (select)
- Bump README.md and CLAUDE.md to v1.8.0, refresh CHANGELOG entry

* docs(agro-erp): document historico_movimientos audit trail and local-replica validation rule

- Add CLAUDE.md rule 5: validate schema changes against the daily local replica of hosting3m_db before assuming production state
- Record the salida_ganado Meta-CRUD model and historico_movimientos audit trail in CLAUDE.md rule 3
- Add CHANGELOG [1.8.1] entry for the schema doc sync and the n8n_db + hosting3m_db backup pipeline extension
- Add README bullet for the historico_movimientos audit feature

---------