### PR TITLE
Feat(livestock): balance de capitalización vs gastos por UPP y por an…

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.html
@@ -102,6 +102,28 @@
     <div class="card-body p-0">
         @if (activeSubTab() === 'RESUMEN') {
         <div class="p-4 rounded-bottom">
+            <div class="card shadow-sm border-0 mb-4">
+                <div class="card-header border-bottom-0 pb-0 d-flex align-items-center justify-content-between">
+                    <h3 class="card-title">Balance por UPP: Capitalización vs Gastos</h3>
+                    <span class="font-weight-bold" [class.text-success]="balanceNetoUpp() >= 0"
+                        [class.text-danger]="balanceNetoUpp() < 0">
+                        Balance Neto: {{ balanceNetoUpp() | currency:'MXN':'symbol-narrow':'1.0-0' }}
+                    </span>
+                </div>
+                <div class="card-body">
+                    @if (uppBalanceSummary().length === 0) {
+                    <div class="text-center text-muted py-4">No hay datos de UPP para este periodo.</div>
+                    } @else {
+                    <apx-chart [series]="uppChartOptions().series" [xaxis]="uppChartOptions().xaxis"
+                        [colors]="uppChartOptions().colors"
+                        [chart]="{ type: 'bar', height: 320, toolbar: { show: false }, background: 'transparent' }"
+                        [plotOptions]="{ bar: { borderRadius: 4, columnWidth: '55%' } }"
+                        [dataLabels]="{ enabled: false }" [legend]="{ show: true, position: 'top' }">
+                    </apx-chart>
+                    }
+                </div>
+            </div>
+
             @if (activeTab() === 'CRIA') {
             <app-reproductive-dashboard [cattleData]="filteredCattleList()"></app-reproductive-dashboard>
             }
@@ -222,6 +244,13 @@
             No hay gastos vinculados a animales específicos en este periodo.
         </div>
         } @else {
+        <div class="card-body border-bottom">
+            <h3 class="card-title">Balance por Animal (Top 10 con más gasto)</h3>
+            <apx-chart [series]="animalBalanceChartOptions().series" [xaxis]="animalBalanceChartOptions().xaxis"
+                [chart]="{ type: 'bar', height: 300, toolbar: { show: false }, background: 'transparent' }"
+                [plotOptions]="{ bar: { borderRadius: 4, columnWidth: '50%', colors: { ranges: [{ from: -999999999, to: 0, color: '#d63939' }, { from: 0, to: 999999999, color: '#2fb344' }] } } }"
+                [dataLabels]="{ enabled: false }"> </apx-chart>
+        </div>
         <div class="card-body border-bottom py-3">
             <div class="text-muted">Mostrar <div class="mx-2 d-inline-block"><select class="form-select form-select-sm"
                         [value]="pageSize()" (change)="changePageSize($event)">
@@ -242,6 +271,8 @@
                         <th class="text-end">Registros</th>
                         <th class="text-end">Gasto Total</th>
                         <th class="text-end">Costo / kg</th>
+                        <th class="text-end">Valor Estimado</th>
+                        <th class="text-end">Balance</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -259,6 +290,13 @@
                         <td class="text-end text-orange">
                             ${{ row.costPerKg | number:'1.2-2' }}/kg
                         </td>
+                        <td class="text-end font-weight-bold text-primary">
+                            ${{ row.valorEstimado | number:'1.2-2' }}
+                        </td>
+                        <td class="text-end font-weight-bold" [class.text-success]="row.balance >= 0"
+                            [class.text-danger]="row.balance < 0">
+                            ${{ row.balance | number:'1.2-2' }}
+                        </td>
                     </tr>
                     }
                 </tbody>
@@ -268,6 +306,8 @@
                         <td class="text-end font-weight-bold text-danger">
                             ${{ totalAnimalCosts() | number:'1.2-2' }}
                         </td>
+                        <td></td>
+                        <td></td>
                         <td></td>
                     </tr>
                 </tfoot>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.ts
@@ -229,6 +229,7 @@ export class MainDashboardComponent implements OnInit {
       .map(([livestockId, stats]) => {
         const animal = this.cattleList().find(a => a.id === livestockId);
         const weightKg = Number(animal?.current_weight_kg || 0);
+        const valorEstimado = weightKg * this.PRECIO_KILO;
         return {
           livestockId,
           rfid:        animal?.rfid_siniiga ?? 'Desconocido',
@@ -237,7 +238,9 @@ export class MainDashboardComponent implements OnInit {
           weightKg,
           total:       stats.total,
           count:       stats.count,
-          costPerKg:   weightKg > 0 ? stats.total / weightKg : 0
+          costPerKg:   weightKg > 0 ? stats.total / weightKg : 0,
+          valorEstimado,
+          balance:     valorEstimado - stats.total
         };
       })
       .sort((a, b) => b.total - a.total);
@@ -245,5 +248,95 @@ export class MainDashboardComponent implements OnInit {
 
   public totalAnimalCosts = computed(() =>
     this.animalCostSummary().reduce((sum, row) => sum + row.total, 0)
+  );
+
+  /** Top 10 animales con más gasto registrado: balance (valor estimado - gasto) para detectar rendimiento negativo */
+  public animalBalanceChartOptions = computed(() => {
+    const rows = this.animalCostSummary().slice(0, 10);
+    return {
+      series: [{
+        name: 'Balance',
+        data: rows.map(r => Number(r.balance.toFixed(2)))
+      }],
+      xaxis: {
+        categories: rows.map(r => r.numero_fuego || `...${r.rfid.slice(-4)}`),
+        labels: { rotate: -45, style: { cssClass: 'text-muted font-monospace' } }
+      }
+    };
+  });
+
+  private static readonly SIN_UPP = 'Sin UPP Asignada';
+  private static readonly GASTOS_GENERALES = 'Gastos Generales';
+
+  /**
+   * Balance por UPP: cruza capitalización del hato (agrupado por upp_origen) contra los gastos
+   * vinculados a esos mismos animales. Los gastos sin livestock_id (o cuyo animal no tiene UPP
+   * asignada) no pueden atribuirse a una UPP real y se agrupan aparte en "Gastos Generales".
+   */
+  public uppBalanceSummary = computed(() => {
+    const cattle = this.filteredCattleList();
+    const expenses = this.filteredExpensesList();
+
+    const grouped = new Map<string, { capitalizacion: number; cabezas: number; gasto: number }>();
+
+    for (const animal of cattle) {
+      const upp = (animal.upp_origen && String(animal.upp_origen).trim()) || MainDashboardComponent.SIN_UPP;
+      const entry = grouped.get(upp) ?? { capitalizacion: 0, cabezas: 0, gasto: 0 };
+      entry.capitalizacion += Number(animal.current_weight_kg || 0) * this.PRECIO_KILO;
+      entry.cabezas += 1;
+      grouped.set(upp, entry);
+    }
+
+    let gastosGenerales = 0;
+    for (const expense of expenses) {
+      const animal = expense.livestock_id ? cattle.find(a => a.id === expense.livestock_id) : null;
+      const upp = animal?.upp_origen && String(animal.upp_origen).trim();
+
+      if (upp) {
+        const entry = grouped.get(upp) ?? { capitalizacion: 0, cabezas: 0, gasto: 0 };
+        entry.gasto += Number(expense.amount || 0);
+        grouped.set(upp, entry);
+      } else {
+        gastosGenerales += Number(expense.amount || 0);
+      }
+    }
+
+    const rows = Array.from(grouped.entries())
+      .map(([upp, v]) => ({
+        upp,
+        capitalizacion: v.capitalizacion,
+        gasto:          v.gasto,
+        cabezas:        v.cabezas,
+        balance:        v.capitalizacion - v.gasto
+      }))
+      .sort((a, b) => b.capitalizacion - a.capitalizacion);
+
+    if (gastosGenerales > 0) {
+      rows.push({
+        upp: MainDashboardComponent.GASTOS_GENERALES,
+        capitalizacion: 0,
+        gasto: gastosGenerales,
+        cabezas: 0,
+        balance: -gastosGenerales
+      });
+    }
+
+    return rows;
+  });
+
+  public uppChartOptions = computed(() => {
+    const rows = this.uppBalanceSummary();
+    return {
+      series: [
+        { name: 'Capitalización', data: rows.map(r => Number(r.capitalizacion.toFixed(2))) },
+        { name: 'Gasto', data: rows.map(r => Number(r.gasto.toFixed(2))) }
+      ],
+      xaxis: { categories: rows.map(r => r.upp) },
+      colors: ['#2fb344', '#d63939']
+    };
+  });
+
+  public balanceNetoUpp = computed(() =>
+    this.uppBalanceSummary().reduce((sum, row) => sum + row.balance, 0)
   );
 }


### PR DESCRIPTION
…imal en el dashboard (#533)

* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

* fix(build): resolve tsconfig path mappings and ng-packagr compilation crash

- Remove localized 'paths' configuration from projects/ui-chat/tsconfig.lib.json to prevent internal ng-packagr destructuring errors.
- Delegate 'core-auth' module resolution to the workspace root tsconfig.json pointing directly to the dist/ directory.
- Enforce clean architectural boundaries by ensuring libraries consume built artifacts rather than raw source code.

* fix(livestock): shorten "Fecha Brucelosis" label in cattle detail modal

Renamed "Fecha Prueba Brucelosis" to "Fecha Brucelosis" in both the ALTA and EDITAR forms of CattleDetailModalComponent for label consistency.

* feat(livestock): add search-by-tag and client-side column sorting to cattle inventory

- Wire the previously non-functional search input to filter by rfid_siniiga, numero_fuego and electronic_rfid (case-insensitive substring match)
- Add sortable column headers (Arete, Socio Dueño, Categoría, Modelo de Negocio, Peso Actual, Estatus Actual) via toggleSort(), with visual ascending/descending indicators
- Introduce filteredCattleList computed signal that always sorts deterministically before rendering, since vw_cattle_kpi has no stable ORDER BY and row order shifted after every save
- Remove the dead `sort` payload field from CattleApiService.getAllLivestock() — confirmed the n8n Meta-CRUD workflow for vw_cattle_kpi ignores it; ordering is now fully resolved client-side

* docs(agro-erp): align v1.8.0 docs with real DB schema and PL/pgSQL engine

- Document upp_origen, historico_movimientos, vw_cattle_kpi and the salida_ganado Meta-CRUD model (wraps sp_procesar_salida_ganado) that were missing from DATABASE_SCHEMA.md and ARCHITECTURE.md
- Fix RBAC bullets that overstated ADMIN-only restrictions on cattle_livestock (delete) and cattle_tenants (select)
- Bump README.md and CLAUDE.md to v1.8.0, refresh CHANGELOG entry

* docs(agro-erp): document historico_movimientos audit trail and local-replica validation rule

- Add CLAUDE.md rule 5: validate schema changes against the daily local replica of hosting3m_db before assuming production state
- Record the salida_ganado Meta-CRUD model and historico_movimientos audit trail in CLAUDE.md rule 3
- Add CHANGELOG [1.8.1] entry for the schema doc sync and the n8n_db + hosting3m_db backup pipeline extension
- Add README bullet for the historico_movimientos audit feature

* feat(livestock): add UPP and per-animal capitalization vs expense balance to dashboard

- Add uppBalanceSummary computed: groups filteredCattleList by upp_origen (capitalización = peso × PRECIO_KILO) and crosses it with filteredExpensesList via livestock_id → animal.upp_origen; expenses with no attributable UPP fall into a "Gastos Generales" bucket
- Add grouped bar chart (Capitalización vs Gasto) plus net balance badge to the Resumen tab, respecting the existing module/species filters
- Extend animalCostSummary with valorEstimado and balance per animal, and add a Top 10 balance bar chart (colored by sign) plus two new columns to the Costo por Animal table

---------