### PR TITLE
Fixes end-to-end failure of the WhatsApp cattle-management agent (#540)

### DIFF
--- a/hosting3m-workspace/package-lock.json
+++ b/hosting3m-workspace/package-lock.json
@@ -8687,9 +8687,9 @@
       }
     },
     "node_modules/piscina": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.1.4.tgz",
-      "integrity": "sha512-7uU4ZnKeQq22t9AsmHGD2w4OYQGonwFnTypDypaWi7Qr2EvQIFVtG8J5D/3bE7W123Wdc9+v4CZDu5hJXVCtBg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/piscina/-/piscina-5.3.0.tgz",
+      "integrity": "sha512-9D3tPBayfoal6l9l4Y8NrMn1jkV718qJoYrla6P51+hh9h0Q+9/1c8KgEnoBQqhguyfgjay4biADI8HJG3pkoA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/hosting3m-workspace/package.json
+++ b/hosting3m-workspace/package.json
@@ -30,7 +30,8 @@
     "dompurify": "^3.2.4",
     "undici": "^6.19.8",
     "picomatch": "^4.0.4",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "piscina": "^5.1.5"
   },
   "dependencies": {
     "@angular/common": "^21.0.0",

--- a/hosting3m-workspace/tsconfig.json
+++ b/hosting3m-workspace/tsconfig.json
@@ -68,7 +68,7 @@
         "projects/agro-erp/src/app/shared/*"
       ],
       "core-auth": [
-        "../core-auth/src/public-api.ts"
+        "projects/core-auth/src/public-api.ts"
       ],
       "core-auth/*": [
         "dist/core-auth/*"

--- a/workflows/09-MCP-Agent-Cattle/v6/v6_MCP_Server_Cattle.json
+++ b/workflows/09-MCP-Agent-Cattle/v6/v6_MCP_Server_Cattle.json
@@ -8,7 +8,7 @@
       "type": "@n8n/n8n-nodes-langchain.mcpTrigger",
       "typeVersion": 2,
       "position": [
-        576,
+        528,
         832
       ],
       "id": "20140a69-ad24-4392-850e-789f2ff32e45",
@@ -28,8 +28,8 @@
       "type": "n8n-nodes-base.postgresTool",
       "typeVersion": 2.6,
       "position": [
-        544,
-        1104
+        208,
+        960
       ],
       "id": "5d209495-6de0-4419-8deb-43efd1f4ba94",
       "name": "get_table_metadata",
@@ -54,8 +54,8 @@
       "type": "n8n-nodes-base.postgresTool",
       "typeVersion": 2.6,
       "position": [
-        800,
-        1104
+        400,
+        1072
       ],
       "id": "a0d3dd3f-0664-4e65-b801-a92684302056",
       "name": "log_cattle_weight",
@@ -79,8 +79,8 @@
       "type": "n8n-nodes-base.postgresTool",
       "typeVersion": 2.6,
       "position": [
-        1040,
-        1072
+        640,
+        1104
       ],
       "id": "84d7567d-a46c-4811-9ff3-6b0b573bed48",
       "name": "log_health_event",
@@ -96,16 +96,16 @@
         "descriptionType": "manual",
         "toolDescription": "Busca la información de un animal en la base de datos del rancho actual. REQUIERE: identificador (arete SINIIGA o fuego) y el tenant_id del contexto del usuario. Si devuelve más de un registro, detén el flujo y pide al usuario que aclare a cuál animal se refiere usando la categoría o especie.",
         "operation": "executeQuery",
-        "query": "SELECT l.id, l.tenant_id, l.rfid_siniiga, l.numero_fuego, l.species, l.category, l.current_status, l.current_weight_kg\nFROM cattle_livestock l\nWHERE (l.rfid_siniiga = $1::text OR l.numero_fuego = $1::text)\n  AND l.tenant_id = $2::int\n  AND EXISTS (\n    SELECT 1 FROM user_companies uc\n    JOIN users u ON u.email = uc.email\n    WHERE u.email = $3::text AND uc.id_company = $2::int AND uc.is_active = true\n  )\nLIMIT 5;\n",
+        "query": "SELECT l.id, l.tenant_id, l.rfid_siniiga, l.numero_fuego, l.species, l.category, l.current_status, l.current_weight_kg\nFROM cattle_livestock l\nWHERE (l.rfid_siniiga = $1::text OR l.numero_fuego = $1::text)\n  AND l.tenant_id = $2::int\n  AND EXISTS (\n    SELECT 1 FROM user_companies uc\n    JOIN users u ON u.email = uc.email\n    WHERE u.email = $3::text AND uc.id_company = $2::int AND uc.is_active = true\n  )\nLIMIT 5;",
         "options": {
-          "queryReplacement": "={{ [ $fromAI('identificador', 'El numero de arete SINIIGA o numero de fuego a buscar', 'string'), $fromAI('tenant_id', 'ID del rancho / tenant_id actual del usuario', 'number'), $fromAI('user_email', 'Email verificado del usuario actual del contexto de sesion', 'string') ] }}"
+          "queryReplacement": "={{ [ $fromAI('identificador', 'El numero de arete SINIIGA o numero de fuego a buscar', 'string'), $fromAI('tenant_id', 'ID del rancho / tenant_id actual del usuario', 'number'), $fromAI('user_email', 'Email verificado del usuario, tal como aparece literalmente en las instrucciones del sistema', 'string') ] }}"
         }
       },
       "type": "n8n-nodes-base.postgresTool",
       "typeVersion": 2.6,
       "position": [
-        336,
-        1040
+        864,
+        1072
       ],
       "id": "090fab19-82ec-406c-9246-b466011a7e4c",
       "name": "get_livestock_info",
@@ -129,8 +129,8 @@
       "type": "n8n-nodes-base.postgresTool",
       "typeVersion": 2.6,
       "position": [
-        1296,
-        992
+        1088,
+        1008
       ],
       "id": "7ee7280c-51d3-4c11-acf2-69cff0c1039b",
       "name": "register_ranch_expense",
@@ -210,7 +210,7 @@
     "timeSavedMode": "fixed",
     "timeSavedPerExecution": 3
   },
-  "versionId": "983f6e82-9590-42d5-b4e8-5f530533f9c2",
+  "versionId": "c08d4c33-5c82-4dda-9254-0d61eb9a6f11",
   "meta": {
     "templateCredsSetupCompleted": true,
     "instanceId": "75957d34f9f0189415b8c82ca3ce42d8f0b464efd869382da2158435b39f044d"
@@ -219,16 +219,10 @@
   "id": "pJ3CEaO70QEiGL0C",
   "tags": [
     {
-      "updatedAt": "2026-06-02T17:44:17.958Z",
-      "createdAt": "2026-06-02T17:44:17.958Z",
-      "id": "6NGDwjjesOlJeGQr",
-      "name": "v6"
-    },
-    {
-      "updatedAt": "2025-12-23T12:12:28.399Z",
-      "createdAt": "2025-12-23T12:12:28.399Z",
-      "id": "RWBzILPfFXEtEcLf",
-      "name": "AI Agent"
+      "updatedAt": "2025-12-31T16:55:06.301Z",
+      "createdAt": "2025-12-31T16:55:06.301Z",
+      "id": "ts9FABk8F02a5xrA",
+      "name": "Agent IA"
     },
     {
       "updatedAt": "2025-12-23T12:12:58.230Z",
@@ -237,10 +231,16 @@
       "name": "Chat"
     },
     {
-      "updatedAt": "2025-12-31T16:55:06.301Z",
-      "createdAt": "2025-12-31T16:55:06.301Z",
-      "id": "ts9FABk8F02a5xrA",
-      "name": "Agent IA"
+      "updatedAt": "2025-12-23T12:12:28.399Z",
+      "createdAt": "2025-12-23T12:12:28.399Z",
+      "id": "RWBzILPfFXEtEcLf",
+      "name": "AI Agent"
+    },
+    {
+      "updatedAt": "2026-06-02T17:44:17.958Z",
+      "createdAt": "2026-06-02T17:44:17.958Z",
+      "id": "6NGDwjjesOlJeGQr",
+      "name": "v6"
     }
   ]
 }

--- a/workflows/09-MCP-Agent-Cattle/v6/v6_WhatsApp_Agent_Cattle.json
+++ b/workflows/09-MCP-Agent-Cattle/v6/v6_WhatsApp_Agent_Cattle.json
@@ -166,7 +166,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.2,
       "position": [
-        448,
+        1344,
         192
       ],
       "id": "de696807-1b04-4e78-89d6-a1f860918919",
@@ -181,7 +181,7 @@
       "type": "@n8n/n8n-nodes-langchain.openAi",
       "typeVersion": 1.8,
       "position": [
-        672,
+        1568,
         96
       ],
       "id": "4b55141d-9940-4072-bf50-73f4c2e01138",
@@ -201,7 +201,7 @@
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
-        896,
+        1792,
         96
       ],
       "id": "15cc1ad9-3763-4b77-a1bb-bc12206d0be6",
@@ -219,7 +219,7 @@
       "type": "n8n-nodes-base.whatsApp",
       "typeVersion": 1.1,
       "position": [
-        1120,
+        2016,
         96
       ],
       "id": "7894f202-fc5f-4d57-9c47-e8bb49de7883",
@@ -243,7 +243,7 @@
       "type": "n8n-nodes-base.whatsApp",
       "typeVersion": 1.1,
       "position": [
-        672,
+        1568,
         288
       ],
       "id": "b784f086-8e7a-4f2c-9d6a-70789e74f5c7",
@@ -398,13 +398,13 @@
     {
       "parameters": {
         "sessionIdType": "customKey",
-        "sessionKey": "={{ $('WhatsApp Trigger').last().json.messages[0].from }}_{{ $json.tenant_id }}",
+        "sessionKey": "={{ $('WhatsApp Trigger').last().json.messages[0].from }}",
         "contextWindowLength": 50
       },
       "type": "@n8n/n8n-nodes-langchain.memoryBufferWindow",
       "typeVersion": 1.3,
       "position": [
-        112,
+        1008,
         160
       ],
       "id": "b452a01d-b2c2-4f6b-9455-31dfc433eeac",
@@ -425,7 +425,7 @@
                 "conditions": [
                   {
                     "id": "18f51475-430c-4447-9753-48e02d415494",
-                    "leftValue": "={{ $json.role }}",
+                    "leftValue": "={{ $('Set Role').item.json.role }}",
                     "rightValue": "ADMIN",
                     "operator": {
                       "type": "string",
@@ -448,7 +448,7 @@
                 "conditions": [
                   {
                     "id": "735583d8-e290-47b7-aab6-36238216fd56",
-                    "leftValue": "={{ $json.role }}",
+                    "leftValue": "={{ $('Set Role').item.json.role }}",
                     "rightValue": "ADMIN",
                     "operator": {
                       "type": "string",
@@ -466,7 +466,7 @@
       "type": "n8n-nodes-base.switch",
       "typeVersion": 3.4,
       "position": [
-        -240,
+        656,
         192
       ],
       "id": "caed1e4d-523c-4646-b0fa-01afb21a4489",
@@ -486,7 +486,7 @@
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
       "position": [
-        -16,
+        880,
         160
       ],
       "id": "f4fa3130-d3f1-4669-9538-883906ef59a0",
@@ -506,7 +506,7 @@
       "type": "@n8n/n8n-nodes-langchain.mcpClientTool",
       "typeVersion": 1.2,
       "position": [
-        240,
+        1136,
         160
       ],
       "id": "83c47eaa-e8ca-4657-a2f8-6206ddaa0314",
@@ -515,7 +515,7 @@
     {
       "parameters": {
         "operation": "executeQuery",
-        "query": "WITH phone_companies AS (\n  -- Extrae las UPPs únicas vinculadas al número para evitar duplicados\n  SELECT DISTINCT \n    u.phone, \n    c.id_company, \n    c.company_name\n  FROM users u\n  JOIN user_companies uc ON u.email = uc.email\n  JOIN companys c ON uc.id_company = c.id_company\n  WHERE u.phone = $1 \n    AND u.is_active = true \n    AND uc.is_active = true\n)\nSELECT \n  pc.phone,\n  -- Evalúa todas las cuentas del teléfono. Si alguna es ADMIN, otorga ADMIN global.\n  (\n    SELECT CASE WHEN bool_or(role = 'ADMIN') THEN 'ADMIN' ELSE 'EDITOR' END \n    FROM users \n    WHERE phone = pc.phone AND is_active = true\n  ) AS global_role,\n  -- Construye el arreglo limpio para inyectarlo al Agente IA\n  json_agg(\n    json_build_object(\n      'id_company', pc.id_company, \n      'company_name', pc.company_name\n    )\n  ) AS available_tenants\nFROM phone_companies pc\nGROUP BY pc.phone;",
+        "query": "WITH phone_companies AS (\n  SELECT DISTINCT \n    u.phone, \n    u.email,\n    c.id_company, \n    c.company_name\n  FROM users u\n  JOIN user_companies uc ON u.email = uc.email\n  JOIN companys c ON uc.id_company = c.id_company\n  WHERE u.phone = $1 \n    AND u.is_active = true \n    AND uc.is_active = true\n)\nSELECT \n  pc.phone,\n  (\n    SELECT CASE WHEN bool_or(role = 'ADMIN') THEN 'ADMIN' ELSE 'EDITOR' END \n    FROM users \n    WHERE phone = pc.phone AND is_active = true\n  ) AS global_role,\n  json_agg(\n    json_build_object(\n      'id_company', pc.id_company, \n      'company_name', pc.company_name,\n      'email', pc.email\n    )\n  ) AS available_tenants,\n  (\n    SELECT id_company \n    FROM user_tenant_selection \n    WHERE phone = pc.phone\n  ) AS selected_tenant_id\nFROM phone_companies pc\nGROUP BY pc.phone;",
         "options": {
           "queryReplacement": "={{ $('Set Message').item.json.number.toString().slice(-10) }}"
         }
@@ -539,15 +539,15 @@
     {
       "parameters": {
         "promptType": "define",
-        "text": "={{ $json.text }}",
+        "text": "={{ $('Set Prompt Final').item.json.prompt_final }}",
         "options": {
-          "systemMessage": "==Rol: Eres el Administrador Virtual de Ganadería de Precisión. Tu objetivo es ayudar al usuario a registrar y consultar datos de campo de forma estructurada.\nHOY ES: {{ $now.setZone('America/Mexico_City').toFormat('yyyy-MM-dd') }} (Usa esto para calcular \"hoy\").\n\n🛑 REGLAS CRÍTICAS DE INTEGRIDAD DE DATOS (MÉTACRUD):\n\n1. NUNCA ASUMAS EL ID DEL ANIMAL: Postgres requiere el UUID (livestock_id) para cualquier registro transaccional. Si el usuario te da un arete SINIIGA o número de fuego, SIEMPRE ejecuta primero la herramienta 'get_livestock_info' para obtener su UUID antes de intentar guardar algo.\n\n2. SANITIZACIÓN DE ARETES (AUDIO Y TEXTO): Es probable que el usuario o el sistema dicte el arete con espacios, comas o guiones (Ej. \"715 690 242\" o \"vaca 19-116\"). Priorizar el identificador electronic_rfid (bolo ruminal/microchip) sobre el arete SINIIGA/fuego cuando el usuario provea ambos, y documentar que SINIIGA es identificador secundario. TU DEBER ESTRICTO es extraer únicamente los caracteres alfanuméricos, eliminar cualquier espacio o símbolo, y concatenarlos en un solo bloque continuo (Ej. \"715690242\" o \"19116\") ANTES de invocar get_livestock_info.\n\n3. ESTRICTA PROHIBICIÓN DE INFERENCIA (ZERO-HALLUCINATION): NUNCA asumas, inventes o adivines parámetros faltantes (como 'event_type', 'category' o 'description'). Si el usuario dice \"lo inyectamos\", ESTÁ ESTRICTAMENTE PROHIBIDO asumir que el evento es 'VACUNACION'. Si falta un solo dato para usar una herramienta, DEBES detener el flujo y preguntar explícitamente al usuario por los datos exactos (Ej. \"¿Qué le inyectaron y por qué motivo?\") ANTES de armar el resumen.\n\n4. MANEJO DE TENANTS Y DESAMBIGUACIÓN (GATEKEEPER ESTRICTO):\nTienes acceso a este arreglo de UPPs permitidas para el usuario actual: {{ $('Set Role').item.json.available_tenants }}\n\n🛑 REGLA DE EJECUCIÓN CONDICIONAL:\n- PASO A: Revisa cuántas UPPs hay en el arreglo proporcionado.\n- PASO B: Si hay 2 O MÁS UPPs, analiza el historial de la conversación. ¿El usuario ya especificó claramente en cuál rancho/UPP quiere operar?\n  - SI LA RESPUESTA ES NO: TIENES ESTRICTAMENTE PROHIBIDO ejecutar 'get_livestock_info', 'log_cattle_weight' o cualquier otra herramienta. Tu ÚNICA acción permitida es responder al usuario con este formato: \"Tienes acceso a más de una UPP [Menciona los nombres de las UPPs disponibles]. ¿En cuál de ellas deseas realizar esta operación?\".\n  - SI LA RESPUESTA ES SÍ (o si solo tiene 1 UPP asignada): Extrae el 'id_company' correspondiente a la selección del usuario y úsalo obligatoriamente como el parámetro 'tenant_id' en cualquier herramienta que lo requiera (get_livestock_info, register_ranch_expense, log_cattle_weight, y cualquier otra que reciba este parámetro).\n\n🛑 REGLA DE TRANSMISIÓN DE DATOS: \nAl ejecutar 'log_cattle_weight', los parámetros DEBEN ser enviados como un objeto JSON con las llaves exactas 'livestock_id' y 'weight_kg'. No envíes arreglos ni listas.\n\n🛠️ DICCIONARIO DE HERRAMIENTAS PERMITIDAS:\n- Consulta: Usa 'get_livestock_info' para mostrar categoría, peso actual y estatus.\n- Pesaje: Usa 'log_cattle_weight' enviando el UUID y el peso numérico.\n- Salud: Usa 'log_health_event' enviando el UUID, event_type y description.\n- Gasto: Usa 'register_ranch_expense' enviando tenant_id, category, amount y description.\n\n✨ PROTOCOLO DE ESTILO:\n- Sé directo, pragmático y orientado a resultados de campo (habla como un administrador ganadero experto).\n- Usa un solo asterisco (*) para resaltar números clave o aretes. NUNCA uses negrita doble (**).\n- Usa Emojis estratégicamente: 🐄, ⚖️, 💉, 📋."
+          "systemMessage": "==Rol: Eres el Administrador Virtual de Ganadería de Precisión. Tu objetivo es ayudar al usuario a registrar y consultar datos de campo de forma estructurada.\nHOY ES: {{ $now.setZone('America/Mexico_City').toFormat('yyyy-MM-dd') }} (Usa esto para calcular \"hoy\").\n\n🛑 REGLAS CRÍTICAS DE INTEGRIDAD DE DATOS (MÉTACRUD):\n\n1. NUNCA ASUMAS EL ID DEL ANIMAL: Postgres requiere el UUID (livestock_id) para cualquier registro transaccional. Si el usuario te da un arete SINIIGA o número de fuego, SIEMPRE ejecuta primero la herramienta 'get_livestock_info' para obtener su UUID antes de intentar guardar algo.\n\n1.b OBLIGATORIEDAD DE RE-VERIFICACIÓN: Nunca respondas \"no encontrado\" o des datos de un animal basándote en el historial de la conversación o en consultas anteriores. CADA VEZ que el usuario pregunte por un animal (aunque ya se haya consultado antes en esta misma sesión), DEBES ejecutar 'get_livestock_info' de nuevo con el identificador exacto proporcionado en este turno, sin excepción.\n\n2. SANITIZACIÓN DE ARETES (AUDIO Y TEXTO): Es probable que el usuario o el sistema dicte el arete con espacios, comas o guiones (Ej. \"715 690 242\" o \"vaca 19-116\"). Priorizar el identificador electronic_rfid (bolo ruminal/microchip) sobre el arete SINIIGA/fuego cuando el usuario provea ambos, y documentar que SINIIGA es identificador secundario. TU DEBER ESTRICTO es extraer únicamente los caracteres alfanuméricos, eliminar cualquier espacio o símbolo, y concatenarlos en un solo bloque continuo (Ej. \"715690242\" o \"19116\") ANTES de invocar get_livestock_info.\n\n3. ESTRICTA PROHIBICIÓN DE INFERENCIA (ZERO-HALLUCINATION): NUNCA asumas, inventes o adivines parámetros faltantes (como 'event_type', 'category' o 'description'). Si el usuario dice \"lo inyectamos\", ESTÁ ESTRICTAMENTE PROHIBIDO asumir que el evento es 'VACUNACION'. Si falta un solo dato para usar una herramienta, DEBES detener el flujo y preguntar explícitamente al usuario por los datos exactos (Ej. \"¿Qué le inyectaron y por qué motivo?\") ANTES de armar el resumen.\n\n4. MANEJO DE TENANTS Y DESAMBIGUACIÓN (GATEKEEPER ESTRICTO):\nTienes acceso a este arreglo de UPPs permitidas para el usuario actual: {{ $('Set Role').item.json.available_tenants }}\n\nEl email verificado del usuario en esta sesión es: {{ $('Resolver Tenant').item.json.user_email }}\n🛑 SIEMPRE usa este valor EXACTO, tal cual aparece aquí, como el parámetro 'user_email' al invocar cualquier herramienta que lo requiera (get_livestock_info, log_cattle_weight, log_health_event, register_ranch_expense). NUNCA inventes, adivines, ni dejes vacío este campo.\n\n🛑 REGLA DE EJECUCIÓN CONDICIONAL:\n- PASO A: Revisa cuántas UPPs hay en el arreglo proporcionado.\n- PASO B: Si hay 2 O MÁS UPPs, analiza el historial de la conversación. ¿El usuario ya especificó claramente en cuál rancho/UPP quiere operar?\n  - SI LA RESPUESTA ES NO: TIENES ESTRICTAMENTE PROHIBIDO ejecutar 'get_livestock_info', 'log_cattle_weight' o cualquier otra herramienta. Tu ÚNICA acción permitida es responder al usuario con este formato: \"Tienes acceso a más de una UPP [Menciona los nombres de las UPPs disponibles]. ¿En cuál de ellas deseas realizar esta operación?\".\n  - SI LA RESPUESTA ES SÍ (o si solo tiene 1 UPP asignada): Extrae el 'id_company' correspondiente a la selección del usuario y úsalo obligatoriamente como el parámetro 'tenant_id' en cualquier herramienta que lo requiera (get_livestock_info, register_ranch_expense, log_cattle_weight, y cualquier otra que reciba este parámetro).\n\n🛑 REGLA DE TRANSMISIÓN DE DATOS: \nAl ejecutar 'log_cattle_weight', los parámetros DEBEN ser enviados como un objeto JSON con las llaves exactas 'livestock_id' y 'weight_kg'. No envíes arreglos ni listas.\n\n🛠️ DICCIONARIO DE HERRAMIENTAS PERMITIDAS:\n- Consulta: Usa 'get_livestock_info' para mostrar categoría, peso actual y estatus.\n- Pesaje: Usa 'log_cattle_weight' enviando el UUID y el peso numérico.\n- Salud: Usa 'log_health_event' enviando el UUID, event_type y description.\n- Gasto: Usa 'register_ranch_expense' enviando tenant_id, category, amount y description.\n\n✨ PROTOCOLO DE ESTILO:\n- Sé directo, pragmático y orientado a resultados de campo (habla como un administrador ganadero experto).\n- Usa un solo asterisco (*) para resaltar números clave o aretes. NUNCA uses negrita doble (**).\n- Usa Emojis estratégicamente: 🐄, ⚖️, 💉, 📋."
         }
       },
       "type": "@n8n/n8n-nodes-langchain.agent",
       "typeVersion": 3.1,
       "position": [
-        48,
+        944,
         -64
       ],
       "id": "8bb0e662-274e-48b3-9efa-e51f4ec46fda",
@@ -583,7 +583,7 @@
             {
               "id": "44868a6c-9c03-472a-8fba-515ceb130462",
               "name": "output",
-              "value": "🔒 Acceso denegado. Este canal es exclusivo para operaciones del Rancho San José.",
+              "value": "=={{ \n(() => {\n  let tenants = [];\n  try { tenants = JSON.parse($('Resolver Tenant').item.json.available_tenants || '[]'); } catch(e) {}\n  const match = tenants.find(t => t.id_company === $('Resolver Tenant').item.json.tenant_id);\n  const rancho = match ? match.company_name : 'tu rancho';\n  return `🔒 Acceso denegado. Tu rol actual no tiene permiso para operar en este canal para ${rancho}. Contacta a un administrador.`;\n})()\n}}",
               "type": "string"
             }
           ]
@@ -593,7 +593,7 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        112,
+        1008,
         336
       ],
       "id": "afb94924-c767-4628-ae58-da42e658e29b",
@@ -673,6 +673,12 @@
               "name": "available_tenants",
               "value": "={{ $json.available_tenants }}",
               "type": "string"
+            },
+            {
+              "id": "c94ad56b-3c0c-45f6-a175-15f22a47b8d8",
+              "name": "selected_tenant_id",
+              "value": "={{ $json.selected_tenant_id || '' }}",
+              "type": "string"
             }
           ]
         },
@@ -689,7 +695,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Node: Resolver Tenant\n// Purpose: Deterministically resolve tenant_id from available_tenants array.\n// Fail-closed: any ambiguity, absence, or malformed data resolves to a\n// non-actionable status (\"ambiguous\" | \"none\"), never a guessed tenant_id.\n\nconst rawTenants = $json.available_tenants;\n\n// Defensive parsing: available_tenants may arrive as a JS array already,\n// or (depending on upstream node) as a JSON string. Never assume shape.\nlet tenants;\nif (Array.isArray(rawTenants)) {\n  tenants = rawTenants;\n} else if (typeof rawTenants === 'string') {\n  try {\n    const parsed = JSON.parse(rawTenants);\n    tenants = Array.isArray(parsed) ? parsed : [];\n  } catch (err) {\n    tenants = [];\n  }\n} else {\n  tenants = [];\n}\n\n// Extra guard: filter out malformed entries missing id_company.\nconst validTenants = tenants.filter(\n  (t) => t && typeof t === 'object' && t.id_company !== undefined && t.id_company !== null\n);\n\nlet tenant_id = null;\nlet tenant_status;\n\nif (validTenants.length === 1) {\n  tenant_id = validTenants[0].id_company;\n  tenant_status = 'resolved';\n} else if (validTenants.length > 1) {\n  tenant_status = 'ambiguous';\n} else {\n  tenant_status = 'none';\n}\n\n// Structured output consumed downstream by Switch Role.\n// tenant_id stays null unless status === 'resolved' — this is the\n// fail-closed contract: downstream nodes must treat null tenant_id\n// as \"do not proceed\" regardless of tenant_status value.\n$input.item.json.tenant_id = tenant_id;\n$input.item.json.tenant_status = tenant_status;\n   \nreturn $input.item;"
+        "jsCode": "// Node: Resolver Tenant\n// Fail-closed con selección por texto del mensaje + preferencia persistida.\n\nfunction normalize(str) {\n  return (str || '')\n    .toString()\n    .normalize('NFD')\n    .replace(/[\\u0300-\\u036f]/g, '')\n    .toLowerCase()\n    .replace(/\\b(upp|rancho|granja|finca|propiedad)\\b/g, '')\n    .replace(/[^a-z0-9]+/g, ' ')\n    .trim();\n}\n\nconst rawTenants = $json.available_tenants;\nlet tenants;\nif (Array.isArray(rawTenants)) {\n  tenants = rawTenants;\n} else if (typeof rawTenants === 'string') {\n  try {\n    const parsed = JSON.parse(rawTenants);\n    tenants = Array.isArray(parsed) ? parsed : [];\n  } catch (err) {\n    tenants = [];\n  }\n} else {\n  tenants = [];\n}\n\nconst validTenants = tenants.filter(\n  (t) => t && typeof t === 'object' && t.id_company !== undefined && t.id_company !== null\n);\n\nlet tenant_id = null;\nlet tenant_status;\nlet tenant_source = null;\n\nconst messageText = $json.text || '';\nconst normalizedMessage = normalize(messageText);\nconst cachedSelection = $json.selected_tenant_id ? Number($json.selected_tenant_id) : null;\n\nif (validTenants.length === 0) {\n  tenant_status = 'none';\n} else if (validTenants.length === 1) {\n  tenant_id = validTenants[0].id_company;\n  tenant_status = 'resolved';\n  tenant_source = 'single';\n} else {\n  const matches = validTenants.filter((t) => {\n    const name = normalize(t.company_name);\n    return name && normalizedMessage.includes(name);\n  });\n\n  if (matches.length === 1) {\n    tenant_id = matches[0].id_company;\n    tenant_status = 'resolved';\n    tenant_source = 'matched_this_message';\n  } else if (cachedSelection && validTenants.some((t) => t.id_company === cachedSelection)) {\n    tenant_id = cachedSelection;\n    tenant_status = 'resolved';\n    tenant_source = 'cached';\n  } else {\n    tenant_status = 'ambiguous';\n  }\n}\n\n$input.item.json.tenant_id = tenant_id;\n\nconst matchedTenant = validTenants.find(t => t.id_company === tenant_id);\n$input.item.json.user_email = matchedTenant ? matchedTenant.email : '';\n\n$input.item.json.tenant_status = tenant_status;\n$input.item.json.tenant_source = tenant_source;\n$input.item.json.available_tenant_names = validTenants.map((t) => t.company_name);\n\nreturn $input.item;"
       },
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
@@ -712,7 +718,7 @@
           "conditions": [
             {
               "id": "d2a60d21-5092-4846-8df0-ef346c7aa456",
-              "leftValue": "={{ $json.tenant_status }}",
+              "leftValue": "={{ $('Resolver Tenant').item.json.tenant_status }}",
               "rightValue": "resolved",
               "operator": {
                 "type": "string",
@@ -727,7 +733,7 @@
       "type": "n8n-nodes-base.if",
       "typeVersion": 2.3,
       "position": [
-        -464,
+        -16,
         288
       ],
       "id": "338ed646-ec89-4c13-af06-0eb69faf57a1",
@@ -750,8 +756,8 @@
       "type": "n8n-nodes-base.set",
       "typeVersion": 3.4,
       "position": [
-        -240,
-        528
+        432,
+        384
       ],
       "id": "c19f02e4-5a6a-40fb-8afb-dabc9c689e96",
       "name": "Set - Mensaje Selección UPP"
@@ -767,8 +773,8 @@
       "type": "n8n-nodes-base.whatsApp",
       "typeVersion": 1.1,
       "position": [
-        112,
-        528
+        656,
+        384
       ],
       "id": "641ada85-eec6-416a-9abb-52b30ff98232",
       "name": "Send Message Tenant",
@@ -779,6 +785,133 @@
           "name": "WhatsApp Account"
         }
       }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO user_tenant_selection (phone, id_company, updated_at)\nVALUES ($1, $2, CURRENT_TIMESTAMP)\nON CONFLICT (phone) DO UPDATE SET id_company = EXCLUDED.id_company, updated_at = CURRENT_TIMESTAMP;",
+        "options": {
+          "queryReplacement": "={{ $json.number.toString().slice(-10) }},{{ $json.tenant_id }}"
+        }
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        -240,
+        208
+      ],
+      "id": "d45c18be-4777-453d-827c-d43ffd8d0cec",
+      "name": "Persist Tenant Selection",
+      "credentials": {
+        "postgres": {
+          "id": "BQrod4uGVzM1nvLw",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 3
+          },
+          "conditions": [
+            {
+              "id": "798d5c0d-78e1-4371-9423-43376ac19d22",
+              "leftValue": "={{ $json.tenant_source }}",
+              "rightValue": "matched_this_message",
+              "operator": {
+                "type": "string",
+                "operation": "equals",
+                "name": "filter.operator.equals"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.3,
+      "position": [
+        -464,
+        288
+      ],
+      "id": "846dc823-29a1-4191-b163-e3d3f5617929",
+      "name": "IF - Nueva Selección de Tenant"
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "INSERT INTO pending_user_query (phone, query_text, created_at)\nVALUES ($1, $2, CURRENT_TIMESTAMP)\nON CONFLICT (phone) DO UPDATE SET query_text = EXCLUDED.query_text, created_at = CURRENT_TIMESTAMP;",
+        "options": {
+          "queryReplacement": "={{ $('Set Message').item.json.number.toString().slice(-10) }},{{ $('Set Message').item.json.text }}"
+        }
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        208,
+        384
+      ],
+      "id": "c2622e6b-947e-4c73-9c52-b081588f38ed",
+      "name": "Guardar Pregunta Pendiente",
+      "credentials": {
+        "postgres": {
+          "id": "BQrod4uGVzM1nvLw",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "operation": "executeQuery",
+        "query": "DELETE FROM pending_user_query\nWHERE phone = $1\nRETURNING query_text;",
+        "options": {
+          "queryReplacement": "={{ $('Set Message').item.json.number.toString().slice(-10) }}"
+        }
+      },
+      "type": "n8n-nodes-base.postgres",
+      "typeVersion": 2.6,
+      "position": [
+        208,
+        192
+      ],
+      "id": "0f200946-6b08-44a9-b5c4-fdeb2d8cbf78",
+      "name": "Recuperar Pregunta Pendiente",
+      "alwaysOutputData": true,
+      "credentials": {
+        "postgres": {
+          "id": "BQrod4uGVzM1nvLw",
+          "name": "Postgres account"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "assignments": {
+          "assignments": [
+            {
+              "id": "934b037d-ecd2-451a-b9c9-e902299c65ed",
+              "name": "prompt_final",
+              "value": "={{ $json.query_text || $('Set Message').item.json.text }}",
+              "type": "string"
+            }
+          ]
+        },
+        "options": {}
+      },
+      "type": "n8n-nodes-base.set",
+      "typeVersion": 3.4,
+      "position": [
+        432,
+        192
+      ],
+      "id": "b9206e12-df75-43a3-85e7-055f91eb5758",
+      "name": "Set Prompt Final"
     }
   ],
   "pinData": {},
@@ -1035,7 +1168,7 @@
       "main": [
         [
           {
-            "node": "IF - Bloquear Tenant Ambiguo",
+            "node": "IF - Nueva Selección de Tenant",
             "type": "main",
             "index": 0
           }
@@ -1046,14 +1179,14 @@
       "main": [
         [
           {
-            "node": "Switch Role",
+            "node": "Recuperar Pregunta Pendiente",
             "type": "main",
             "index": 0
           }
         ],
         [
           {
-            "node": "Set - Mensaje Selección UPP",
+            "node": "Guardar Pregunta Pendiente",
             "type": "main",
             "index": 0
           }
@@ -1065,6 +1198,68 @@
         [
           {
             "node": "Send Message Tenant",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Persist Tenant Selection": {
+      "main": [
+        [
+          {
+            "node": "IF - Bloquear Tenant Ambiguo",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "IF - Nueva Selección de Tenant": {
+      "main": [
+        [
+          {
+            "node": "Persist Tenant Selection",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "IF - Bloquear Tenant Ambiguo",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Guardar Pregunta Pendiente": {
+      "main": [
+        [
+          {
+            "node": "Set - Mensaje Selección UPP",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Recuperar Pregunta Pendiente": {
+      "main": [
+        [
+          {
+            "node": "Set Prompt Final",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Set Prompt Final": {
+      "main": [
+        [
+          {
+            "node": "Switch Role",
             "type": "main",
             "index": 0
           }
@@ -1082,7 +1277,7 @@
     "availableInMCP": true,
     "timeSavedPerExecution": 5
   },
-  "versionId": "f1035260-f610-469f-901d-f5ac77571e4e",
+  "versionId": "9aa00760-67ee-4f9e-9192-2dc0f97d7385",
   "meta": {
     "templateCredsSetupCompleted": true,
     "instanceId": "75957d34f9f0189415b8c82ca3ce42d8f0b464efd869382da2158435b39f044d"


### PR DESCRIPTION
* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

* fix(build): resolve tsconfig path mappings and ng-packagr compilation crash

- Remove localized 'paths' configuration from projects/ui-chat/tsconfig.lib.json to prevent internal ng-packagr destructuring errors.
- Delegate 'core-auth' module resolution to the workspace root tsconfig.json pointing directly to the dist/ directory.
- Enforce clean architectural boundaries by ensuring libraries consume built artifacts rather than raw source code.

* fix(livestock): shorten "Fecha Brucelosis" label in cattle detail modal

Renamed "Fecha Prueba Brucelosis" to "Fecha Brucelosis" in both the ALTA and EDITAR forms of CattleDetailModalComponent for label consistency.

* feat(livestock): add search-by-tag and client-side column sorting to cattle inventory

- Wire the previously non-functional search input to filter by rfid_siniiga, numero_fuego and electronic_rfid (case-insensitive substring match)
- Add sortable column headers (Arete, Socio Dueño, Categoría, Modelo de Negocio, Peso Actual, Estatus Actual) via toggleSort(), with visual ascending/descending indicators
- Introduce filteredCattleList computed signal that always sorts deterministically before rendering, since vw_cattle_kpi has no stable ORDER BY and row order shifted after every save
- Remove the dead `sort` payload field from CattleApiService.getAllLivestock() — confirmed the n8n Meta-CRUD workflow for vw_cattle_kpi ignores it; ordering is now fully resolved client-side

* docs(agro-erp): align v1.8.0 docs with real DB schema and PL/pgSQL engine

- Document upp_origen, historico_movimientos, vw_cattle_kpi and the salida_ganado Meta-CRUD model (wraps sp_procesar_salida_ganado) that were missing from DATABASE_SCHEMA.md and ARCHITECTURE.md
- Fix RBAC bullets that overstated ADMIN-only restrictions on cattle_livestock (delete) and cattle_tenants (select)
- Bump README.md and CLAUDE.md to v1.8.0, refresh CHANGELOG entry

* docs(agro-erp): document historico_movimientos audit trail and local-replica validation rule

- Add CLAUDE.md rule 5: validate schema changes against the daily local replica of hosting3m_db before assuming production state
- Record the salida_ganado Meta-CRUD model and historico_movimientos audit trail in CLAUDE.md rule 3
- Add CHANGELOG [1.8.1] entry for the schema doc sync and the n8n_db + hosting3m_db backup pipeline extension
- Add README bullet for the historico_movimientos audit feature

* feat(livestock): add UPP and per-animal capitalization vs expense balance to dashboard

- Add uppBalanceSummary computed: groups filteredCattleList by upp_origen (capitalización = peso × PRECIO_KILO) and crosses it with filteredExpensesList via livestock_id → animal.upp_origen; expenses with no attributable UPP fall into a "Gastos Generales" bucket
- Add grouped bar chart (Capitalización vs Gasto) plus net balance badge to the Resumen tab, respecting the existing module/species filters
- Extend animalCostSummary with valorEstimado and balance per animal, and add a Top 10 balance bar chart (colored by sign) plus two new columns to the Costo por Animal table

* feat(agro-erp): wire AI chat auth channel and harden WhatsApp Cattle Agent

- Add apiUrl_ai to core-auth config/interceptor so AgroERP web chat requests reach the AI endpoint with the Bearer token attached
- Fix WhatsApp Agent bug that overwrote the sender's phone number with message text, breaking tenant/role resolution for nearly all users
- Fix broken node reference in the image-rejection path
- Add deterministic multi-tenant gate (Resolver Tenant + IF - Bloquear Tenant Ambiguo) before invoking the AI Agent, replacing prompt-only enforcement
- Scope WhatsApp conversation memory by tenant, not just phone number
- Align livestock identification priority (RFID/microchip over SINIIGA) across prompt and node documentation
- Register register_ranch_expense in the WhatsApp Agent's tool dictionary
- Archive v5 workflow snapshot; update v6 README for both channels



* fix(whatsapp-trigger): configure Meta webhook verify token and subscribe to messages field Root cause: webhook subscription was never validated because the Verify Token field in Meta contained an access token instead of the n8n WhatsApp Trigger node ID. Corrected token and subscribed only to the 'messages' field to avoid unnecessary event noise.

fix(ai-agent): resolve "No prompt specified" by referencing Set Message node explicitly AI Agent prompt used $json.text, which broke whenever an intermediate node (Resolver Tenant, Persist Tenant Selection) rebuilt the item and dropped the field. Switched to $('Set Message').item.json.text as an interim fix, later superseded by Set Prompt Final (see below).

fix(tenant-cache): propagate selected_tenant_id through Set Role and normalize phone format Set Role dropped selected_tenant_id (Postgres SELECT result) because it wasn't declared as an assignment, so the cached tenant selection never reached Resolver Tenant. Also fixed phone number format mismatch (10-digit vs. country-code-prefixed) between Get User Role and Persist Tenant Selection, which prevented the cached selection lookup from ever matching.

fix(user-email): inject verified user email into AI Agent system prompt instead of cross-workflow node reference get_livestock_info runs inside a separate MCP sub-workflow, so it cannot reference nodes from the caller workflow ($('Resolver Tenant') resulted in "Referenced node doesn't exist"). Fixed by having Get User Role return each tenant's email, Resolver Tenant surface user_email for the active tenant, and the AI Agent system prompt state that value literally so the model passes it via $fromAI at tool-call time. Also added rule 1.b to the system prompt forbidding the model from answering "not found" from conversation memory without re-invoking get_livestock_info.

* fix(security): override piscina to patched version to resolve prototype pollution RCE

piscina@5.1.4 is pulled in transitively by @angular/build and ng-packagr as a build-time worker pool dependency. Neither package has published a version using a patched piscina yet, and updating @angular/build/@angular/ssr/etc. to the latest 21.2.x patch is blocked by ng-apexcharts@1.17.1's peer dependency on @angular/common@^20.0.0. Forced via npm overrides instead, which is independent of the Angular version conflict. Verified all library projects (core-auth, ui-chat, ui-pdf-export) and dashboard build cleanly with piscina@5.3.0.

Resolves GHSA (Dependabot alert #100).

fix(build): add missing core-auth path mapping to root tsconfig

hotel-website failed to build with "Could not resolve core-auth" because ui-chat imports TenantService from core-auth, but the root tsconfig.json only had path mappings for ui-chat and ui-pdf-export. ui-chat's own tsconfig.lib.json already had the correct mapping (core-auth -> dist/core-auth), it just wasn't inherited by consumers building against the root config. Added the same mapping at the root level. Build order requirement unchanged: core-auth must be built before any project consuming it transitively (ui-chat, hotel-website).

---------