### PR TITLE
Configures Dependabot to open dependency-update  (#554)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "develop"
+    ignore:
+      - dependency-name: "@angular/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "npm"
     directory: "/infrastructure/upload-file/app"
     schedule:


### PR DESCRIPTION
* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

* fix(build): resolve tsconfig path mappings and ng-packagr compilation crash

- Remove localized 'paths' configuration from projects/ui-chat/tsconfig.lib.json to prevent internal ng-packagr destructuring errors.
- Delegate 'core-auth' module resolution to the workspace root tsconfig.json pointing directly to the dist/ directory.
- Enforce clean architectural boundaries by ensuring libraries consume built artifacts rather than raw source code.

* fix(livestock): shorten "Fecha Brucelosis" label in cattle detail modal

Renamed "Fecha Prueba Brucelosis" to "Fecha Brucelosis" in both the ALTA and EDITAR forms of CattleDetailModalComponent for label consistency.

* feat(livestock): add search-by-tag and client-side column sorting to cattle inventory

- Wire the previously non-functional search input to filter by rfid_siniiga, numero_fuego and electronic_rfid (case-insensitive substring match)
- Add sortable column headers (Arete, Socio Dueño, Categoría, Modelo de Negocio, Peso Actual, Estatus Actual) via toggleSort(), with visual ascending/descending indicators
- Introduce filteredCattleList computed signal that always sorts deterministically before rendering, since vw_cattle_kpi has no stable ORDER BY and row order shifted after every save
- Remove the dead `sort` payload field from CattleApiService.getAllLivestock() — confirmed the n8n Meta-CRUD workflow for vw_cattle_kpi ignores it; ordering is now fully resolved client-side

* docs(agro-erp): align v1.8.0 docs with real DB schema and PL/pgSQL engine

- Document upp_origen, historico_movimientos, vw_cattle_kpi and the salida_ganado Meta-CRUD model (wraps sp_procesar_salida_ganado) that were missing from DATABASE_SCHEMA.md and ARCHITECTURE.md
- Fix RBAC bullets that overstated ADMIN-only restrictions on cattle_livestock (delete) and cattle_tenants (select)
- Bump README.md and CLAUDE.md to v1.8.0, refresh CHANGELOG entry

* docs(agro-erp): document historico_movimientos audit trail and local-replica validation rule

- Add CLAUDE.md rule 5: validate schema changes against the daily local replica of hosting3m_db before assuming production state
- Record the salida_ganado Meta-CRUD model and historico_movimientos audit trail in CLAUDE.md rule 3
- Add CHANGELOG [1.8.1] entry for the schema doc sync and the n8n_db + hosting3m_db backup pipeline extension
- Add README bullet for the historico_movimientos audit feature

* feat(livestock): add UPP and per-animal capitalization vs expense balance to dashboard

- Add uppBalanceSummary computed: groups filteredCattleList by upp_origen (capitalización = peso × PRECIO_KILO) and crosses it with filteredExpensesList via livestock_id → animal.upp_origen; expenses with no attributable UPP fall into a "Gastos Generales" bucket
- Add grouped bar chart (Capitalización vs Gasto) plus net balance badge to the Resumen tab, respecting the existing module/species filters
- Extend animalCostSummary with valorEstimado and balance per animal, and add a Top 10 balance bar chart (colored by sign) plus two new columns to the Costo por Animal table

* feat(agro-erp): wire AI chat auth channel and harden WhatsApp Cattle Agent

- Add apiUrl_ai to core-auth config/interceptor so AgroERP web chat requests reach the AI endpoint with the Bearer token attached
- Fix WhatsApp Agent bug that overwrote the sender's phone number with message text, breaking tenant/role resolution for nearly all users
- Fix broken node reference in the image-rejection path
- Add deterministic multi-tenant gate (Resolver Tenant + IF - Bloquear Tenant Ambiguo) before invoking the AI Agent, replacing prompt-only enforcement
- Scope WhatsApp conversation memory by tenant, not just phone number
- Align livestock identification priority (RFID/microchip over SINIIGA) across prompt and node documentation
- Register register_ranch_expense in the WhatsApp Agent's tool dictionary
- Archive v5 workflow snapshot; update v6 README for both channels



* fix(whatsapp-trigger): configure Meta webhook verify token and subscribe to messages field Root cause: webhook subscription was never validated because the Verify Token field in Meta contained an access token instead of the n8n WhatsApp Trigger node ID. Corrected token and subscribed only to the 'messages' field to avoid unnecessary event noise.

fix(ai-agent): resolve "No prompt specified" by referencing Set Message node explicitly AI Agent prompt used $json.text, which broke whenever an intermediate node (Resolver Tenant, Persist Tenant Selection) rebuilt the item and dropped the field. Switched to $('Set Message').item.json.text as an interim fix, later superseded by Set Prompt Final (see below).

fix(tenant-cache): propagate selected_tenant_id through Set Role and normalize phone format Set Role dropped selected_tenant_id (Postgres SELECT result) because it wasn't declared as an assignment, so the cached tenant selection never reached Resolver Tenant. Also fixed phone number format mismatch (10-digit vs. country-code-prefixed) between Get User Role and Persist Tenant Selection, which prevented the cached selection lookup from ever matching.

fix(user-email): inject verified user email into AI Agent system prompt instead of cross-workflow node reference get_livestock_info runs inside a separate MCP sub-workflow, so it cannot reference nodes from the caller workflow ($('Resolver Tenant') resulted in "Referenced node doesn't exist"). Fixed by having Get User Role return each tenant's email, Resolver Tenant surface user_email for the active tenant, and the AI Agent system prompt state that value literally so the model passes it via $fromAI at tool-call time. Also added rule 1.b to the system prompt forbidding the model from answering "not found" from conversation memory without re-invoking get_livestock_info.

* fix(security): override piscina to patched version to resolve prototype pollution RCE

piscina@5.1.4 is pulled in transitively by @angular/build and ng-packagr as a build-time worker pool dependency. Neither package has published a version using a patched piscina yet, and updating @angular/build/@angular/ssr/etc. to the latest 21.2.x patch is blocked by ng-apexcharts@1.17.1's peer dependency on @angular/common@^20.0.0. Forced via npm overrides instead, which is independent of the Angular version conflict. Verified all library projects (core-auth, ui-chat, ui-pdf-export) and dashboard build cleanly with piscina@5.3.0.

Resolves GHSA (Dependabot alert #100).

fix(build): add missing core-auth path mapping to root tsconfig

hotel-website failed to build with "Could not resolve core-auth" because ui-chat imports TenantService from core-auth, but the root tsconfig.json only had path mappings for ui-chat and ui-pdf-export. ui-chat's own tsconfig.lib.json already had the correct mapping (core-auth -> dist/core-auth), it just wasn't inherited by consumers building against the root config. Added the same mapping at the root level. Build order requirement unchanged: core-auth must be built before any project consuming it transitively (ui-chat, hotel-website).

* chore(dependabot): target develop branch for automated PRs

Dependabot was opening PRs directly against main, bypassing the develop -> main promotion flow used for all other changes. Added target-branch: develop to each ecosystem entry so future dependency PRs follow the same process as manual changes.

* chore(dependabot): ignore major version updates for @angular/* and typescript

@angular/core, @angular/router, and other @angular/* packages must be upgraded together in lockstep (see PRs #553, #550) — a single-package major bump breaks peer dependency resolution across the Angular ecosystem. Additionally, ng-apexcharts@1.17.1 currently pins peer dep @angular/common@^20.0.0, blocking any Angular 21+ major upgrade until that package (or its replacement) supports newer Angular majors.

typescript major bumps (#551, 5.9.3 -> 7.0.2) are equally unsafe to apply automatically, since Angular's supported TypeScript range is tied to each Angular major release.

Both should be upgraded manually as a deliberate, coordinated migration — not via automated single-dependency PRs. Minor/patch updates for both remain unaffected and will continue to be proposed by Dependabot as before.

---------