### PR TITLE
Livestock Dashboard — Búsqueda, Tipado, Paginación Reutilizable, Aler…

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/src/app/core/services/theme.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/core/services/theme.service.ts
@@ -20,7 +20,7 @@ export class ThemeService {
     // 4. Efecto mágico: Actualiza el HTML automáticamente
     effect(() => {
       const theme = this.currentTheme();
-      document.body.setAttribute('data-bs-theme', theme);
+      document.documentElement.setAttribute('data-bs-theme', theme);
       localStorage.setItem('theme', theme);
     });
   }

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/engorda-dashboard/engorda-dashboard.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/engorda-dashboard/engorda-dashboard.component.html
@@ -29,8 +29,8 @@
         <div class="card shadow-sm border-0 h-100">
             <div class="card-body text-center d-flex flex-column justify-content-center">
                 <div class="subheader mb-2 text-primary font-weight-bold">ADG Promedio del Lote</div>
-                <div class="h1 mb-0 text-primary" style="font-size: 3rem;">
-                    {{ stats().avgAdg }} <span style="font-size: 1.5rem" class="text-muted">kg/día</span>
+                <div class="h1 mb-0 text-primary">
+                    {{ stats().avgAdg }} <span class="h4 text-muted">kg/día</span>
                 </div>
             </div>
         </div>
@@ -40,8 +40,8 @@
         <div class="card shadow-sm border-0 h-100">
             <div class="card-body text-center d-flex flex-column justify-content-center">
                 <div class="subheader mb-2 text-primary font-weight-bold">Peso Biológico Promedio</div>
-                <div class="h1 mb-0 text-primary" style="font-size: 3rem;">
-                    {{ stats().avgWeight }} <span style="font-size: 1.5rem" class="text-muted">kg</span>
+                <div class="h1 mb-0 text-primary">
+                    {{ stats().avgWeight }} <span class="h4 text-muted">kg</span>
                 </div>
             </div>
         </div>
@@ -57,7 +57,7 @@
             [colors]="weightChartOptions().colors"
             [chart]="{ type: 'bar', height: 320, toolbar: { show: false }, background: 'transparent' }"
             [plotOptions]="{ bar: { borderRadius: 4, horizontal: false, columnWidth: '50%' } }"
-            [dataLabels]="{ enabled: false }" [theme]="{ mode: 'dark' }"> </apx-chart>
+            [dataLabels]="{ enabled: false }" [theme]="{ mode: themeService.currentTheme() }"> </apx-chart>
     </div>
 </div>
 }

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/engorda-dashboard/engorda-dashboard.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/engorda-dashboard/engorda-dashboard.component.ts
@@ -1,6 +1,8 @@
-import { Component, input, computed, ChangeDetectionStrategy } from '@angular/core';
+import { Component, input, computed, ChangeDetectionStrategy, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgApexchartsModule } from 'ng-apexcharts';
+import { Livestock } from '../../../models/livestock.model';
+import { ThemeService } from '@core/services/theme.service';
 
 @Component({
   selector: 'app-engorda-dashboard',
@@ -10,8 +12,10 @@ import { NgApexchartsModule } from 'ng-apexcharts';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class EngordaDashboardComponent {
+  public themeService = inject(ThemeService);
+
   // Recibimos los datos filtrados por Especie desde el Main Dashboard
-  public cattleData = input<any[]>([]);
+  public cattleData = input<Livestock[]>([]);
 
   // 🚀 Blindaje de negocio: Filtramos estrictamente los destinados a ENGORDA
   public validEngordaData = computed(() => {
@@ -35,7 +39,7 @@ export class EngordaDashboardComponent {
   // 🚀 Configuración Reactiva para la Gráfica de Barras (Distribución de Peso por Especie)
   public weightChartOptions = computed(() => {
     const data = this.validEngordaData();
-    const sorted = [...data].sort((a, b) => b.current_weight_kg - a.current_weight_kg);
+    const sorted = [...data].sort((a, b) => Number(b.current_weight_kg || 0) - Number(a.current_weight_kg || 0));
 
     return {
       series: [{
@@ -43,7 +47,7 @@ export class EngordaDashboardComponent {
         data: sorted.map(a => Number(a.current_weight_kg || 0))
       }],
       xaxis: {
-        categories: sorted.map(a => a.numero_fuego || `...${a.rfid_siniiga.slice(-4)}`),
+        categories: sorted.map(a => a.numero_fuego || `...${(a.rfid_siniiga ?? '').slice(-4)}`),
         labels: { rotate: -45, style: { cssClass: 'text-muted font-monospace' } }
       },
       colors: ['#206bc4']

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.html
@@ -83,7 +83,11 @@
             <li class="nav-item">
                 <a class="nav-link font-weight-bold" [class.active]="activeSubTab() === 'INVENTARIO'"
                     (click)="setSubTab('INVENTARIO')" style="cursor: pointer;">Inventario Detallado ({{
-                    filteredCattleList().length }})</a>
+                    filteredCattleList().length }})
+                    @if (missingUppCount() > 0) {
+                    <span class="badge bg-warning-lt ms-1">{{ missingUppCount() }} sin UPP</span>
+                    }
+                </a>
             </li>
             <li class="nav-item">
                 <a class="nav-link font-weight-bold" [class.active]="activeSubTab() === 'GASTOS'"
@@ -114,12 +118,36 @@
                     @if (uppBalanceSummary().length === 0) {
                     <div class="text-center text-muted py-4">No hay datos de UPP para este periodo.</div>
                     } @else {
+                    @if (sinUppSummary(); as sinUpp) {
+                    <div class="alert alert-warning d-flex align-items-start gap-3 mb-3" role="alert">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="icon alert-icon" width="24" height="24"
+                            viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none"
+                            stroke-linecap="round" stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M12 9v2m0 4v.01" />
+                            <path
+                                d="M5.07 19H19a2 2 0 0 0 1.75 -2.75L13.75 3.5a2 2 0 0 0 -3.5 0L3.25 16.25A2 2 0 0 0 5.07 19" />
+                        </svg>
+                        <div>
+                            <strong>{{ sinUpp.cabezas }} de {{ filteredCattleList().length }} animales ({{
+                                (sinUpp.cabezas / filteredCattleList().length * 100) | number:'1.0-0' }}%) sin UPP
+                                asignada.</strong>
+                            Capitalización: {{ sinUpp.capitalizacion | currency:'MXN':'symbol-narrow':'1.0-0' }} —
+                            esta cifra no aparece en el balance por rancho de abajo.
+                        </div>
+                    </div>
+                    }
+                    @if (uppChartDisplayRows().length > 0) {
                     <apx-chart [series]="uppChartOptions().series" [xaxis]="uppChartOptions().xaxis"
                         [colors]="uppChartOptions().colors"
                         [chart]="{ type: 'bar', height: 320, toolbar: { show: false }, background: 'transparent' }"
                         [plotOptions]="{ bar: { borderRadius: 4, columnWidth: '55%' } }"
-                        [dataLabels]="{ enabled: false }" [legend]="{ show: true, position: 'top' }">
+                        [dataLabels]="{ enabled: false }" [legend]="{ show: true, position: 'top' }"
+                        [theme]="{ mode: themeService.currentTheme() }">
                     </apx-chart>
+                    } @else {
+                    <div class="text-center text-muted py-4">Todos los animales están sin UPP asignada.</div>
+                    }
                     }
                 </div>
             </div>
@@ -136,12 +164,27 @@
 
         @if (activeSubTab() === 'INVENTARIO') {
         <div class="card-body border-bottom py-3">
-            <div class="text-muted">Mostrar <div class="mx-2 d-inline-block"><select class="form-select form-select-sm"
-                        [value]="pageSize()" (change)="changePageSize($event)">
-                        <option value="10">10</option>
-                        <option value="25">25</option>
-                        <option value="50">50</option>
-                    </select></div> registros</div>
+            <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2">
+                <div class="text-muted">Mostrar <div class="mx-2 d-inline-block"><select class="form-select form-select-sm"
+                            [value]="pagination.pageSize()" (change)="pagination.changePageSize($event)">
+                            <option value="10">10</option>
+                            <option value="25">25</option>
+                            <option value="50">50</option>
+                        </select></div> registros</div>
+                <div class="input-icon" style="max-width: 320px;">
+                    <span class="input-icon-addon">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                            stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round"
+                            stroke-linejoin="round">
+                            <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                            <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />
+                            <path d="M21 21l-6 -6" />
+                        </svg>
+                    </span>
+                    <input type="text" class="form-control form-control-sm" placeholder="Buscar por arete, fuego o RFID..."
+                        [value]="inventorySearch()" (input)="setInventorySearch($any($event.target).value)">
+                </div>
+            </div>
         </div>
         <div class="table-responsive">
             <table class="table card-table table-vcenter text-nowrap datatable table-hover mb-0">
@@ -166,7 +209,12 @@
                             <div class="font-monospace text-primary font-weight-bold">{{ animal.rfid_siniiga }}</div>
                         </td>
                         <td><strong>{{ animal.numero_fuego || 'S/N' }}</strong></td>
-                        <td>{{ animal.category }}</td>
+                        <td>
+                            {{ animal.category }}
+                            @if (!animal.upp_origen?.trim()) {
+                            <span class="badge bg-warning-lt d-block mt-1">Sin UPP</span>
+                            }
+                        </td>
                         <td><span class="badge"
                                 [class.bg-green-lt]="animal.current_status === 'ACTIVO' || animal.current_status === 'PREÑADA'"
                                 [class.bg-danger-lt]="animal.current_status === 'VACÍA'">{{ animal.current_status
@@ -184,7 +232,7 @@
         @if (activeSubTab() === 'GASTOS') {
         <div class="card-body border-bottom py-3">
             <div class="text-muted">Mostrar <div class="mx-2 d-inline-block"><select class="form-select form-select-sm"
-                        [value]="pageSize()" (change)="changePageSize($event)">
+                        [value]="pagination.pageSize()" (change)="pagination.changePageSize($event)">
                         <option value="10">10</option>
                         <option value="25">25</option>
                         <option value="50">50</option>
@@ -249,11 +297,11 @@
             <apx-chart [series]="animalBalanceChartOptions().series" [xaxis]="animalBalanceChartOptions().xaxis"
                 [chart]="{ type: 'bar', height: 300, toolbar: { show: false }, background: 'transparent' }"
                 [plotOptions]="{ bar: { borderRadius: 4, columnWidth: '50%', colors: { ranges: [{ from: -999999999, to: 0, color: '#d63939' }, { from: 0, to: 999999999, color: '#2fb344' }] } } }"
-                [dataLabels]="{ enabled: false }"> </apx-chart>
+                [dataLabels]="{ enabled: false }" [theme]="{ mode: themeService.currentTheme() }"> </apx-chart>
         </div>
         <div class="card-body border-bottom py-3">
             <div class="text-muted">Mostrar <div class="mx-2 d-inline-block"><select class="form-select form-select-sm"
-                        [value]="pageSize()" (change)="changePageSize($event)">
+                        [value]="pagination.pageSize()" (change)="pagination.changePageSize($event)">
                         <option value="10">10</option>
                         <option value="25">25</option>
                         <option value="50">50</option>
@@ -318,14 +366,14 @@
 
         @if (activeSubTab() !== 'RESUMEN' && activeSubTab() !== 'POR_ANIMAL') {
         <div class="card-footer d-flex align-items-center border-top">
-            <p class="m-0 text-muted">Mostrando <span>{{ showingStart() }}</span> a <span>{{ showingEnd() }}</span> de
+            <p class="m-0 text-muted">Mostrando <span>{{ pagination.showingStart() }}</span> a <span>{{ pagination.showingEnd() }}</span> de
                 un total disponible</p>
             <ul class="pagination m-0 ms-auto">
-                <li class="page-item" [class.disabled]="currentPage() === 1"><a class="page-link"
-                        (click)="changePage(-1)" style="cursor: pointer;">Anterior</a></li>
-                <li class="page-item active"><a class="page-link">{{ currentPage() }} de {{ totalPages() }}</a></li>
-                <li class="page-item" [class.disabled]="currentPage() === totalPages()"><a class="page-link"
-                        (click)="changePage(1)" style="cursor: pointer;">Siguiente</a></li>
+                <li class="page-item" [class.disabled]="pagination.currentPage() === 1"><a class="page-link"
+                        (click)="pagination.changePage(-1)" style="cursor: pointer;">Anterior</a></li>
+                <li class="page-item active"><a class="page-link">{{ pagination.currentPage() }} de {{ pagination.totalPages() }}</a></li>
+                <li class="page-item" [class.disabled]="pagination.currentPage() === pagination.totalPages()"><a class="page-link"
+                        (click)="pagination.changePage(1)" style="cursor: pointer;">Siguiente</a></li>
             </ul>
         </div>
         }

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.ts
@@ -8,6 +8,10 @@ import { ReproductiveDashboardComponent } from '../reproductive-dashboard/reprod
 import { EngordaDashboardComponent } from '../engorda-dashboard/engorda-dashboard.component';
 import { ExpenseModalComponent } from '../../../expenses/components/expense-modal/expense-modal.component';
 import { TenantService } from 'core-auth';
+import { ThemeService } from '@core/services/theme.service';
+import { Livestock } from '../../../models/livestock.model';
+import { Expense } from '../../../models/expense.model';
+import { Paginator } from '../../utils/paginator';
 
 @Component({
   selector: 'app-main-dashboard',
@@ -19,13 +23,14 @@ import { TenantService } from 'core-auth';
 export class MainDashboardComponent implements OnInit {
   private cattleApi = inject(CattleApiService);
   private tenantService = inject(TenantService);
+  public themeService = inject(ThemeService);
   private router = inject(Router);
   private route = inject(ActivatedRoute);
 
   public PRECIO_KILO = 65.00;
 
-  public cattleList = signal<any[]>([]);
-  public expensesList = signal<any[]>([]);
+  public cattleList = signal<Livestock[]>([]);
+  public expensesList = signal<Expense[]>([]);
   public isLoading = signal<boolean>(true);
 
   // Navegación y Filtros de Trazabilidad Biológica
@@ -34,9 +39,11 @@ export class MainDashboardComponent implements OnInit {
   public selectedSpecies = signal<string>('TODOS'); // 🚀 Filtro maestro de especie
   public showExpenseModal = signal<boolean>(false);
 
-  // Controladores de Paginación Única
-  public currentPage = signal(1);
-  public pageSize = signal(10);
+  // 🔎 Búsqueda reactiva del tab Inventario Detallado
+  public inventorySearch = signal<string>('');
+
+  // Controlador de Paginación Reutilizable (ver mejora #3: composable basado en signals)
+  public pagination = new Paginator(() => this.currentDataset().length);
 
   // Bridge reactivo: convierte los queryParams del Router en un Signal nativo de Angular
   private queryParams = toSignal(this.route.queryParamMap);
@@ -78,8 +85,8 @@ export class MainDashboardComponent implements OnInit {
       const rawResponse: any = cattleRaw;
 
       // Si n8n regresa el array directo, se asigna. Si viene envuelto en { data: [...] }, se extrae de forma segura.
-      this.cattleList.set(Array.isArray(rawResponse) ? rawResponse : (rawResponse?.data || []));
-      this.expensesList.set(Array.isArray(expensesRaw) ? expensesRaw : []);
+      this.cattleList.set((Array.isArray(rawResponse) ? rawResponse : (rawResponse?.data || [])) as Livestock[]);
+      this.expensesList.set((Array.isArray(expensesRaw) ? expensesRaw : []) as Expense[]);
 
     } catch (error) {
       console.error('Error en el Data Pipeline:', error);
@@ -147,29 +154,41 @@ export class MainDashboardComponent implements OnInit {
     });
   });
 
+  // 🚩 Cuenta de animales sin UPP asignada, para el badge de alerta del inventario
+  public missingUppCount = computed(() =>
+    this.filteredCattleList().filter(a => !a.upp_origen?.trim()).length
+  );
+
+  // 🔎 Inventario filtrado por búsqueda reactiva (rfid_siniiga, numero_fuego o electronic_rfid)
+  public inventorySearchedList = computed(() => {
+    const query = this.inventorySearch().trim().toLowerCase();
+    const list = this.filteredCattleList();
+    if (!query) return list;
+
+    return list.filter(animal =>
+      animal.rfid_siniiga?.toLowerCase().includes(query) ||
+      animal.numero_fuego?.toLowerCase().includes(query) ||
+      animal.electronic_rfid?.toLowerCase().includes(query)
+    );
+  });
+
   private currentDataset = computed(() => {
-    return this.activeSubTab() === 'GASTOS' ? this.filteredExpensesList() : this.filteredCattleList();
+    const tab = this.activeSubTab();
+    if (tab === 'GASTOS') return this.filteredExpensesList();
+    if (tab === 'INVENTARIO') return this.inventorySearchedList();
+    return this.filteredCattleList();
   });
-
-  public totalPages = computed(() => Math.ceil(this.currentDataset().length / this.pageSize()) || 1);
-
-  public showingStart = computed(() => {
-    if (this.currentDataset().length === 0) return 0;
-    return ((this.currentPage() - 1) * this.pageSize()) + 1;
-  });
-
-  public showingEnd = computed(() => Math.min(this.currentPage() * this.pageSize(), this.currentDataset().length));
 
   public paginatedCattleList = computed(() => {
     if (this.activeSubTab() !== 'INVENTARIO') return [];
-    const startIndex = (this.currentPage() - 1) * this.pageSize();
-    return this.filteredCattleList().slice(startIndex, startIndex + this.pageSize());
+    const startIndex = (this.pagination.currentPage() - 1) * this.pagination.pageSize();
+    return this.inventorySearchedList().slice(startIndex, startIndex + this.pagination.pageSize());
   });
 
   public paginatedExpensesList = computed(() => {
     if (this.activeSubTab() !== 'GASTOS') return [];
-    const startIndex = (this.currentPage() - 1) * this.pageSize();
-    return this.filteredExpensesList().slice(startIndex, startIndex + this.pageSize());
+    const startIndex = (this.pagination.currentPage() - 1) * this.pagination.pageSize();
+    return this.filteredExpensesList().slice(startIndex, startIndex + this.pagination.pageSize());
   });
 
   public setTab(tab: 'CRIA' | 'ENGORDA') {
@@ -184,24 +203,17 @@ export class MainDashboardComponent implements OnInit {
 
   public setSubTab(subTab: 'RESUMEN' | 'INVENTARIO' | 'GASTOS' | 'POR_ANIMAL') {
     this.activeSubTab.set(subTab);
-    this.currentPage.set(1);
+    this.pagination.reset();
   }
 
   public setSpecies(species: string) {
     this.selectedSpecies.set(species);
-    this.currentPage.set(1);
+    this.pagination.reset();
   }
 
-  public changePageSize(event: Event) {
-    this.pageSize.set(Number((event.target as HTMLSelectElement).value));
-    this.currentPage.set(1);
-  }
-
-  public changePage(delta: number) {
-    const newPage = this.currentPage() + delta;
-    if (newPage >= 1 && newPage <= this.totalPages()) {
-      this.currentPage.set(newPage);
-    }
+  public setInventorySearch(query: string) {
+    this.inventorySearch.set(query);
+    this.pagination.reset();
   }
 
   public biomasaTotal = computed(() => {
@@ -214,7 +226,9 @@ export class MainDashboardComponent implements OnInit {
 
   /** Ranking de gastos por animal: agrupa filteredExpensesList por livestock_id y cruza con cattleList */
   public animalCostSummary = computed(() => {
-    const expenses = this.filteredExpensesList().filter(e => e.livestock_id);
+    const expenses = this.filteredExpensesList().filter(
+      (e): e is Expense & { livestock_id: string } => !!e.livestock_id
+    );
     const grouped = new Map<string, { total: number; count: number }>();
 
     for (const e of expenses) {
@@ -324,8 +338,19 @@ export class MainDashboardComponent implements OnInit {
     return rows;
   });
 
+  /** Fila "Sin UPP Asignada" separada del chart: se muestra como tarjeta de alerta en vez de barra,
+   *  ya que su magnitud (mayoría del hato) aplasta visualmente a los UPP operativamente relevantes. */
+  public sinUppSummary = computed(() =>
+    this.uppBalanceSummary().find(row => row.upp === MainDashboardComponent.SIN_UPP)
+  );
+
+  // Filas que sí se grafican en el chart de Balance por UPP (excluye "Sin UPP Asignada")
+  public uppChartDisplayRows = computed(() =>
+    this.uppBalanceSummary().filter(row => row.upp !== MainDashboardComponent.SIN_UPP)
+  );
+
   public uppChartOptions = computed(() => {
-    const rows = this.uppBalanceSummary();
+    const rows = this.uppChartDisplayRows();
     return {
       series: [
         { name: 'Capitalización', data: rows.map(r => Number(r.capitalizacion.toFixed(2))) },

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.html
@@ -20,8 +20,8 @@
     <div class="col-md-4">
         <div class="card shadow-sm border-0 h-100">
             <div class="card-body text-center d-flex flex-column justify-content-center">
-                <div class="subheader mb-2">Tasa de Preñez Global</div>
-                <div class="h1 mb-0 text-primary" style="font-size: 3rem;">{{ stats().tasa }}%</div>
+                <div class="subheader mb-2 font-weight-bold">Tasa de Preñez Global</div>
+                <div class="h1 mb-0 text-primary">{{ stats().tasa }}%</div>
                 <small class="text-muted mt-2">{{ stats().prenadas }} de {{ stats().total }} vientres preñados</small>
             </div>
         </div>
@@ -34,7 +34,8 @@
             </div>
             <div class="card-body">
                 <apx-chart [series]="getChartOptions().series" [labels]="getChartOptions().labels"
-                    [colors]="getChartOptions().colors" [chart]="{ type: 'donut', height: 250 }">
+                    [colors]="getChartOptions().colors" [chart]="{ type: 'donut', height: 250 }"
+                    [theme]="{ mode: themeService.currentTheme() }">
                 </apx-chart>
             </div>
         </div>
@@ -64,7 +65,7 @@
             <div class="text-muted">
                 Mostrar
                 <div class="mx-2 d-inline-block">
-                    <select class="form-select form-select-sm" [value]="pageSize()" (change)="changePageSize($event)">
+                    <select class="form-select form-select-sm" [value]="pagination.pageSize()" (change)="pagination.changePageSize($event)">
                         <option value="10">10</option>
                         <option value="25">25</option>
                         <option value="50">50</option>
@@ -107,16 +108,16 @@
 
     <div class="card-footer d-flex align-items-center border-top">
         <p class="m-0 text-muted">
-            Mostrando <span>{{ showingStart() }}</span> a <span>{{ showingEnd() }}</span>
+            Mostrando <span>{{ pagination.showingStart() }}</span> a <span>{{ pagination.showingEnd() }}</span>
             de <span>{{ data().length }}</span> vientres bajo control
         </p>
         <ul class="pagination m-0 ms-auto">
-            <li class="page-item" [class.disabled]="currentPage() === 1">
-                <a class="page-link" (click)="changePage(-1)" style="cursor: pointer;">Ant</a>
+            <li class="page-item" [class.disabled]="pagination.currentPage() === 1">
+                <a class="page-link" (click)="pagination.changePage(-1)" style="cursor: pointer;">Ant</a>
             </li>
-            <li class="page-item active"><a class="page-link">{{ currentPage() }} de {{ totalPages() }}</a></li>
-            <li class="page-item" [class.disabled]="currentPage() === totalPages()">
-                <a class="page-link" (click)="changePage(1)" style="cursor: pointer;">Sig</a>
+            <li class="page-item active"><a class="page-link">{{ pagination.currentPage() }} de {{ pagination.totalPages() }}</a></li>
+            <li class="page-item" [class.disabled]="pagination.currentPage() === pagination.totalPages()">
+                <a class="page-link" (click)="pagination.changePage(1)" style="cursor: pointer;">Sig</a>
             </li>
         </ul>
     </div>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.ts
@@ -1,6 +1,9 @@
-import { Component, input, computed, ChangeDetectionStrategy, signal } from '@angular/core';
+import { Component, input, computed, ChangeDetectionStrategy, signal, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { NgApexchartsModule } from 'ng-apexcharts';
+import { Livestock } from '../../../models/livestock.model';
+import { Paginator } from '../../utils/paginator';
+import { ThemeService } from '@core/services/theme.service';
 
 @Component({
   selector: 'app-reproductive-dashboard',
@@ -10,8 +13,9 @@ import { NgApexchartsModule } from 'ng-apexcharts';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ReproductiveDashboardComponent {
+  public themeService = inject(ThemeService);
 
-  public cattleData = input<any[]>([]);
+  public cattleData = input<Livestock[]>([]);
 
   // 🚀 Blindaje de datos: Mapeo estricto a la columna 'business_model' de PostgreSQL
   public data = computed(() => this.cattleData().filter(a => a.business_model === 'CRIA'));
@@ -19,41 +23,18 @@ export class ReproductiveDashboardComponent {
   // Controladores de Estado de Interfaz
   public isTableCollapsed = signal(true);
 
-  // 🚀 Sistema de Paginación Reactiva Interno
-  public currentPage = signal(1);
-  public pageSize = signal(10);
-
-  public totalPages = computed(() => Math.ceil(this.data().length / this.pageSize()) || 1);
-
-  public showingStart = computed(() => {
-    if (this.data().length === 0) return 0;
-    return ((this.currentPage() - 1) * this.pageSize()) + 1;
-  });
-
-  public showingEnd = computed(() => Math.min(this.currentPage() * this.pageSize(), this.data().length));
+  // 🚀 Paginación Reutilizable (composable basado en signals, compartido con main-dashboard)
+  public pagination = new Paginator(() => this.data().length);
 
   // Slice de datos en memoria basado en la página seleccionada
   public paginatedData = computed(() => {
-    const startIndex = (this.currentPage() - 1) * this.pageSize();
-    return this.data().slice(startIndex, startIndex + this.pageSize());
+    const startIndex = (this.pagination.currentPage() - 1) * this.pagination.pageSize();
+    return this.data().slice(startIndex, startIndex + this.pagination.pageSize());
   });
 
   public toggleTable() {
     this.isTableCollapsed.update(state => !state);
-    this.currentPage.set(1); // Reset de seguridad al colapsar/expandir
-  }
-
-  public changePageSize(event: Event) {
-    const size = Number((event.target as HTMLSelectElement).value);
-    this.pageSize.set(size);
-    this.currentPage.set(1);
-  }
-
-  public changePage(delta: number) {
-    const newPage = this.currentPage() + delta;
-    if (newPage >= 1 && newPage <= this.totalPages()) {
-      this.currentPage.set(newPage);
-    }
+    this.pagination.reset(); // Reset de seguridad al colapsar/expandir
   }
 
   // Indicadores Clínicos Derivados

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/utils/paginator.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/utils/paginator.ts
@@ -1,0 +1,38 @@
+import { signal, computed } from '@angular/core';
+
+/**
+ * Paginación en memoria basada en signals. Cada instancia mantiene su propio
+ * estado (currentPage/pageSize), parametrizada por una función que reporta
+ * la longitud del dataset actualmente activo.
+ */
+export class Paginator {
+  public readonly currentPage = signal(1);
+  public readonly pageSize = signal(10);
+
+  constructor(private readonly totalItemsFn: () => number) {}
+
+  public readonly totalPages = computed(() => Math.ceil(this.totalItemsFn() / this.pageSize()) || 1);
+
+  public readonly showingStart = computed(() => {
+    if (this.totalItemsFn() === 0) return 0;
+    return ((this.currentPage() - 1) * this.pageSize()) + 1;
+  });
+
+  public readonly showingEnd = computed(() => Math.min(this.currentPage() * this.pageSize(), this.totalItemsFn()));
+
+  public changePageSize(event: Event) {
+    this.pageSize.set(Number((event.target as HTMLSelectElement).value));
+    this.currentPage.set(1);
+  }
+
+  public changePage(delta: number) {
+    const newPage = this.currentPage() + delta;
+    if (newPage >= 1 && newPage <= this.totalPages()) {
+      this.currentPage.set(newPage);
+    }
+  }
+
+  public reset() {
+    this.currentPage.set(1);
+  }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/models/expense.model.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/models/expense.model.ts
@@ -1,0 +1,13 @@
+export interface Expense {
+  id: string;
+  expense_date: string;
+  category: string;
+  description?: string;
+  amount: number;
+  quantity?: number;
+  unit_measure?: string;
+  livestock_id?: string;
+  rfid_siniiga?: string;
+  business_model?: string;
+  health_event_id?: string;
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/models/livestock.model.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/models/livestock.model.ts
@@ -1,0 +1,17 @@
+export interface Livestock {
+  id: string;
+  business_model: 'CRIA' | 'ENGORDA';
+  species?: string;
+  category?: string;
+  current_status?: string;
+  current_weight_kg?: number;
+  adg_lifetime_kg?: number;
+  rfid_siniiga?: string;
+  numero_fuego?: string;
+  electronic_rfid?: string;
+  upp_origen?: string;
+  metadata?: string | { species?: string; [key: string]: unknown };
+  last_palpation_result?: string;
+  current_gestation_days?: number;
+  condicion_utero?: string;
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/main-layout/main-layout.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/main-layout/main-layout.component.html
@@ -4,7 +4,7 @@
 
     <app-header></app-header>
 
-    <div class="page-wrapper">
+    <div class="page-wrapper" [class.expanded-content]="layoutService.sidebarCollapsed()">
         <div class="page-body">
             <div class="container-xl pt-4">
                 <router-outlet></router-outlet>

--- a/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/main-layout/main-layout.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/main-layout/main-layout.component.ts
@@ -6,6 +6,7 @@ import { TenantService } from 'core-auth';
 import { SidebarComponent } from '../sidebar/sidebar.component';
 import { HeaderComponent } from '../header/header.component';
 import { AiChatComponent } from 'ui-chat';
+import { LayoutService } from '@shared/services/layout.service';
 
 @Component({
   selector: 'app-main-layout',
@@ -17,6 +18,7 @@ import { AiChatComponent } from 'ui-chat';
 })
 export class MainLayoutComponent implements OnInit {
   private tenantService = inject(TenantService);
+  public layoutService = inject(LayoutService);
 
   public currentTenant = this.tenantService.activeTenant;
   readonly showIosPrompt = signal<boolean>(false);

--- a/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.scss
+++ b/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.scss
@@ -37,3 +37,15 @@
         width: auto !important;
     }
 }
+
+@media (min-width: 992px) {
+
+    /* Estado colapsado en escritorio: icon-only, sincronizado con .page-wrapper.expanded-content */
+    .navbar-vertical.collapsed {
+        width: 5rem !important;
+    }
+
+    .navbar-vertical.collapsed .nav-link-title {
+        display: none !important;
+    }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/index.html
+++ b/hosting3m-workspace/projects/agro-erp/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-bs-theme="dark">
 
 <head>
   <meta charset="utf-8">
@@ -28,14 +28,10 @@
     :root {
       font-family: 'Inter', sans-serif;
     }
-
-    body {
-      background-color: #f4f6fa;
-    }
   </style>
 </head>
 
-<body data-bs-theme="light"> <app-root></app-root>
+<body> <app-root></app-root>
 
   <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
…tas de UPP + Fix de Layout y Theming (#562)

* fix(api): sanitize date inputs to prevent sql cascade failures

- Add strict type validation for 'check_in', 'check_out', and 'created_at' fields in the Build Query router.
- Discard non-date payload strings to prevent PostgreSQL transaction aborts (invalid input syntax for type date).
- Ensure backend resilience against contaminated frontend query parameters during GETALL operations. fix(booking): resolve guest id parsing error on creation

- Update response mapping in 'createFutureReservation' and 'processCheckin' methods.
- Implement intelligent payload detection to support both Object and Array response structures from the CRUD API.
- Prevent 'undefined' exceptions and silent failures during the reservation workflow.

* feat(config): rebrand AI assistant widget for Agro ERP multi-domain environment

chore(assets): integrate new agro-industrial logo for floating chat widget

* fix(routing): resolve broken navigation link to admin/personal route

- Correct routerLink in sidebar from '/personal' to '/admin/personal'.
- Root cause: the path segment 'personal' is a lazy-loaded child of the 'admin' prefix declared in app.routes.ts; the absolute link omitted the parent prefix, preventing Angular Router from matching any route and leaving <router-outlet> empty.

* feat(admin): implement edit & delete actions for UPP personnel

Add edit and delete functionality to the user-list cards, including the user-form-modal wired for both insert and update flows, and fix missing Tabler Icons webfont that was hiding the action buttons.



* feat(livestock): implement edit action for cattle inventory records

Add EDITAR flow to cattle-detail-modal with pre-filled form for updating animal characteristics (arete, category, business model, status, weight, birth date). Wire updateLivestock via Meta-CRUD update operation and remove unused AuthService injection from CattleApiService.



* feat(agroerp): integrate web manifest and implement responsive ios pwa installation prompt

feat(pwa): add web manifest and ios installation detection prompt to dashboard layout

* fix(pwa): enforce root-absolute icon paths to restore android installation alongside ios prompt

* fix(pwa): add required 512x512 splash icon and enforce root manifest link to restore android install prompt

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(index): enforce root-absolute paths for PWA assets to fix deep-route icon resolution

* fix(pwa): elevate service worker and manifest to domain root for global scope jurisdiction

* fix(build): correct asset glob output paths and update deprecated PWA meta tags

* fix(pwa): resolve PWA installability failures on Android and iOS

- Generate icon-192x192.png and icon-512x512.png at correct dimensions (source logo was 95x95 declared as 192/512 — Chrome rejects mismatched sizes)
- Add purpose "any maskable" to manifest icons for Android TWA launcher support
- Rewrite sw.js with install/activate/fetch lifecycle and offline app-shell cache
- Add theme-color meta tag and point apple-touch-icon to real 192px asset

* fix(pwa): resolve agro-erp PWA installability failures on Android and iOS

- Resize icon-192x192.png and icon-512x512.png to actual declared dimensions (files were 1024x1024 copies of logo_agroerp.png — Chrome rejects size mismatch)
- Add "output": "/" to agro-erp assets in angular.json to place sw.js and manifest.webmanifest at server root instead of dist/browser/public/ (404 fix)
- Add theme-color meta tag and update apple-touch-icon refs to sized 192px asset
- Remove inline comment with emoji from service worker registration script

* fix(finance): remove conditional 18% VAT calculation from reservation totals

- Eliminate `* 1.18` multiplier logic across reservation and check-in workflows when an invoice is requested.
- Refactor calculation methods in checkin-form, reservation-form, reservation-manager, and dashboard components to enforce flat base pricing.
- Preserve the invoice toggle state (`is_invoiced` / `requiresInvoice`) strictly as an informative boolean flag.
- Clean up residual unused mathematical variables and conditional dependencies identified during the codebase sweep.

* feat(booking): add payment_method field to check-in form

* fix(booking): include payment_method in hotel_bookings API payload

* feat(finance): add payment method filter and grouping to income report

* fix(finance): exclude cancelled bookings from group totals and add table footer sums

* feat(finance): add room-level cost tracking with maintenance ticket linkage
- Add optional cost field to maintenance ticket modal
- Add getExpensesByRoom() to ExpenseService
- Add Costos tab to RoomDetailModal with expense + ticket cost summary
- Add onRegisterExpense output to open ExpenseFormModal with pre-set roomId
- Add room selector and maintenance ticket selector to ExpenseFormModal
- Add maintenance_ticket_id to Expense model and MetaCRUD allowed_fields
- Add per-room cost breakdown tab to DailyReportModal (finanzas)
- Wire expenseRoomId signal in DashboardComponent



* feat(agro-erp): add per-animal cost tracking with health event linkage

- Add getExpensesByAnimal() and getHealthLogsByAnimal() to CattleApiService
- Add animal search filter (reactive, by RFID/numero_fuego) and health event selector to ExpenseModal; support preSelectedAnimal input for locked context
- Add COSTOS action type to CattleDetailModal with KPI cards (total cost, current weight, cost/kg), expense table with health event badge, and nested ExpenseModal sub-modal for in-context expense registration
- Add cash icon button in CattleList actions column to open COSTOS view
- Add animalCostSummary computed and Per Animal sub-tab to MainDashboard with ranking table (RFID, biomass, total cost, cost/kg) and footer total



* feat(livestock): add cattle exit (salida) traceability with TB/BR compliance gate

- Extend cattle_livestock with upp_origen, tb_test_date, br_test_date; migrate current_status CHECK to include CUARENTENA
- Add historico_movimientos audit table and sp_procesar_salida_ganado: atomic status change (VENDIDO + upp_origen=NULL) + audit insert, row-locked via FOR UPDATE to prevent double-processing on concurrent RFID reads
- Extend sp_procesar_salida_ganado to validate TB/Brucelosis test dates (<=60 days). Normative rejection returns {success:false, motivo} instead of raising, so callers can distinguish a business rejection from a real data/SQL error
- Register 'salida_ganado' model in crud_models and add a whitelisted 'call_sp' operation to the Meta-CRUD gateway (Security Validation + Build Query) to invoke the SP through the existing generic endpoint, with no new n8n workflow
- Fix vw_cattle_kpi: view predated this migration and listed columns explicitly, so it never inherited upp_origen/tb_test_date/br_test_date
- Add SALIDA action to cattle-detail-modal (compliance preview + confirm flow) and a new action button in cattle-list; add UPP/TB/BR fields to the ALTA/EDITAR forms so ranch staff can manage them without SQL



* feat(admin): implement UPP (Unidad de Producción Pecuaria) CRUD flow

- Add UppFormModalComponent scaffold with Signals (input/model/output), mirroring UserFormModalComponent
- Add updateField/updateMetadataField mutators to isolate root columns from the JSONB metadata column (SINIIGA: clave_upp, folio_holograma, curp, rfc, superficie_ha, fecha_alta)
- Wire TenantListComponent to TenantService.availableTenants() so users only see the UPPs they have access to
- Gate edit/create actions to per-tenant ADMIN role; add read-only mode for non-admin tenants via isReadonly input
- Add AdminService.getCompanyById/saveCompany against the companys Meta-CRUD model; auto-link new UPPs via saveUserCompany
- Rename sidebar "Socios Inversores" to "Unidades de Producción (UPP)", gated to ADMIN role, pointing to /admin/tenants
- Extend Company model with business_type and metadata typing
- Update DATABASE_SCHEMA.md docs for companys/UPP JSONB mapping

* fix(build): resolve tsconfig path mappings and ng-packagr compilation crash

- Remove localized 'paths' configuration from projects/ui-chat/tsconfig.lib.json to prevent internal ng-packagr destructuring errors.
- Delegate 'core-auth' module resolution to the workspace root tsconfig.json pointing directly to the dist/ directory.
- Enforce clean architectural boundaries by ensuring libraries consume built artifacts rather than raw source code.

* fix(livestock): shorten "Fecha Brucelosis" label in cattle detail modal

Renamed "Fecha Prueba Brucelosis" to "Fecha Brucelosis" in both the ALTA and EDITAR forms of CattleDetailModalComponent for label consistency.

* feat(livestock): add search-by-tag and client-side column sorting to cattle inventory

- Wire the previously non-functional search input to filter by rfid_siniiga, numero_fuego and electronic_rfid (case-insensitive substring match)
- Add sortable column headers (Arete, Socio Dueño, Categoría, Modelo de Negocio, Peso Actual, Estatus Actual) via toggleSort(), with visual ascending/descending indicators
- Introduce filteredCattleList computed signal that always sorts deterministically before rendering, since vw_cattle_kpi has no stable ORDER BY and row order shifted after every save
- Remove the dead `sort` payload field from CattleApiService.getAllLivestock() — confirmed the n8n Meta-CRUD workflow for vw_cattle_kpi ignores it; ordering is now fully resolved client-side

* docs(agro-erp): align v1.8.0 docs with real DB schema and PL/pgSQL engine

- Document upp_origen, historico_movimientos, vw_cattle_kpi and the salida_ganado Meta-CRUD model (wraps sp_procesar_salida_ganado) that were missing from DATABASE_SCHEMA.md and ARCHITECTURE.md
- Fix RBAC bullets that overstated ADMIN-only restrictions on cattle_livestock (delete) and cattle_tenants (select)
- Bump README.md and CLAUDE.md to v1.8.0, refresh CHANGELOG entry

* docs(agro-erp): document historico_movimientos audit trail and local-replica validation rule

- Add CLAUDE.md rule 5: validate schema changes against the daily local replica of hosting3m_db before assuming production state
- Record the salida_ganado Meta-CRUD model and historico_movimientos audit trail in CLAUDE.md rule 3
- Add CHANGELOG [1.8.1] entry for the schema doc sync and the n8n_db + hosting3m_db backup pipeline extension
- Add README bullet for the historico_movimientos audit feature

* feat(livestock): add UPP and per-animal capitalization vs expense balance to dashboard

- Add uppBalanceSummary computed: groups filteredCattleList by upp_origen (capitalización = peso × PRECIO_KILO) and crosses it with filteredExpensesList via livestock_id → animal.upp_origen; expenses with no attributable UPP fall into a "Gastos Generales" bucket
- Add grouped bar chart (Capitalización vs Gasto) plus net balance badge to the Resumen tab, respecting the existing module/species filters
- Extend animalCostSummary with valorEstimado and balance per animal, and add a Top 10 balance bar chart (colored by sign) plus two new columns to the Costo por Animal table

* feat(agro-erp): wire AI chat auth channel and harden WhatsApp Cattle Agent

- Add apiUrl_ai to core-auth config/interceptor so AgroERP web chat requests reach the AI endpoint with the Bearer token attached
- Fix WhatsApp Agent bug that overwrote the sender's phone number with message text, breaking tenant/role resolution for nearly all users
- Fix broken node reference in the image-rejection path
- Add deterministic multi-tenant gate (Resolver Tenant + IF - Bloquear Tenant Ambiguo) before invoking the AI Agent, replacing prompt-only enforcement
- Scope WhatsApp conversation memory by tenant, not just phone number
- Align livestock identification priority (RFID/microchip over SINIIGA) across prompt and node documentation
- Register register_ranch_expense in the WhatsApp Agent's tool dictionary
- Archive v5 workflow snapshot; update v6 README for both channels



* fix(whatsapp-trigger): configure Meta webhook verify token and subscribe to messages field Root cause: webhook subscription was never validated because the Verify Token field in Meta contained an access token instead of the n8n WhatsApp Trigger node ID. Corrected token and subscribed only to the 'messages' field to avoid unnecessary event noise.

fix(ai-agent): resolve "No prompt specified" by referencing Set Message node explicitly AI Agent prompt used $json.text, which broke whenever an intermediate node (Resolver Tenant, Persist Tenant Selection) rebuilt the item and dropped the field. Switched to $('Set Message').item.json.text as an interim fix, later superseded by Set Prompt Final (see below).

fix(tenant-cache): propagate selected_tenant_id through Set Role and normalize phone format Set Role dropped selected_tenant_id (Postgres SELECT result) because it wasn't declared as an assignment, so the cached tenant selection never reached Resolver Tenant. Also fixed phone number format mismatch (10-digit vs. country-code-prefixed) between Get User Role and Persist Tenant Selection, which prevented the cached selection lookup from ever matching.

fix(user-email): inject verified user email into AI Agent system prompt instead of cross-workflow node reference get_livestock_info runs inside a separate MCP sub-workflow, so it cannot reference nodes from the caller workflow ($('Resolver Tenant') resulted in "Referenced node doesn't exist"). Fixed by having Get User Role return each tenant's email, Resolver Tenant surface user_email for the active tenant, and the AI Agent system prompt state that value literally so the model passes it via $fromAI at tool-call time. Also added rule 1.b to the system prompt forbidding the model from answering "not found" from conversation memory without re-invoking get_livestock_info.

* fix(security): override piscina to patched version to resolve prototype pollution RCE

piscina@5.1.4 is pulled in transitively by @angular/build and ng-packagr as a build-time worker pool dependency. Neither package has published a version using a patched piscina yet, and updating @angular/build/@angular/ssr/etc. to the latest 21.2.x patch is blocked by ng-apexcharts@1.17.1's peer dependency on @angular/common@^20.0.0. Forced via npm overrides instead, which is independent of the Angular version conflict. Verified all library projects (core-auth, ui-chat, ui-pdf-export) and dashboard build cleanly with piscina@5.3.0.

Resolves GHSA (Dependabot alert #100).

fix(build): add missing core-auth path mapping to root tsconfig

hotel-website failed to build with "Could not resolve core-auth" because ui-chat imports TenantService from core-auth, but the root tsconfig.json only had path mappings for ui-chat and ui-pdf-export. ui-chat's own tsconfig.lib.json already had the correct mapping (core-auth -> dist/core-auth), it just wasn't inherited by consumers building against the root config. Added the same mapping at the root level. Build order requirement unchanged: core-auth must be built before any project consuming it transitively (ui-chat, hotel-website).

* chore(dependabot): target develop branch for automated PRs

Dependabot was opening PRs directly against main, bypassing the develop -> main promotion flow used for all other changes. Added target-branch: develop to each ecosystem entry so future dependency PRs follow the same process as manual changes.

* chore(dependabot): ignore major version updates for @angular/* and typescript

@angular/core, @angular/router, and other @angular/* packages must be upgraded together in lockstep (see PRs #553, #550) — a single-package major bump breaks peer dependency resolution across the Angular ecosystem. Additionally, ng-apexcharts@1.17.1 currently pins peer dep @angular/common@^20.0.0, blocking any Angular 21+ major upgrade until that package (or its replacement) supports newer Angular majors.

typescript major bumps (#551, 5.9.3 -> 7.0.2) are equally unsafe to apply automatically, since Angular's supported TypeScript range is tied to each Angular major release.

Both should be upgraded manually as a deliberate, coordinated migration — not via automated single-dependency PRs. Minor/patch updates for both remain unaffected and will continue to be proposed by Dependabot as before.

* feat(agro-erp/dashboard): add inventory search, typed models, reusable pagination and UPP alerts

Reduce deuda técnica en el dashboard de ganado y cierra un gap operativo: sin buscador ni alerta visual, los ranchos con animales sin upp_origen asignado quedaban indetectables en la vista de Inventario, y el filtrado de gastos por UPP (uppBalanceSummary) los agrupaba silenciosamente en "Gastos Generales".

- Inventario: input de búsqueda reactivo (signal) por rfid_siniiga, numero_fuego o electronic_rfid, con reset automático de página.
- Tipado: nuevas interfaces Livestock/Expense (features/livestock/models) reemplazan any[]/any en main-dashboard, reproductive-dashboard y engorda-dashboard.
- Paginación: extrae la lógica duplicada (currentPage/pageSize/totalPages/ changePage/changePageSize) a la clase Paginator basada en signals (dashboard/utils/paginator.ts), reutilizada por main-dashboard y reproductive-dashboard sin alterar el comportamiento visible.
- Badge "Sin UPP" por fila + contador en el header de la tab Inventario Detallado para detectar animales sin upp_origen asignado.
- Alinea el tema oscuro de la gráfica donut de reproductive-dashboard con el ya existente en engorda-dashboard.

No modifica backend, Meta-CRUD ni queries a n8n.



* fix(agro-erp/layout): sidebar collapse toggle + dashboard visual consistency

Corrige un bug funcional del layout y ajusta consistencia visual del dashboard de ganado (Tabler UI). Cambios exclusivamente de CSS/HTML/ theming — sin tocar datos, filtros, paginación ni Meta-CRUD.

- Sidebar: el botón « no colapsaba nada. Causa raíz doble: faltaba la regla CSS de escritorio (≥992px) para .navbar-vertical.collapsed (solo existía, e invertida, dentro del media query mobile), y main-layout.component nunca inyectaba LayoutService ni aplicaba .expanded-content al .page-wrapper. Se agregó la regla desktop (5rem, icon-only) y se conectó el binding faltante.

- Chart "Balance por UPP": la categoría "Sin UPP Asignada" (200/206 animales) aplastaba visualmente a los UPP operativos en el chart de barras. Se separó en una tarjeta de alerta aparte (conteo, % y capitalización real); el chart y el KPI de balance neto conservan el dataset completo sin cambios de negocio.

- Tipografía: normaliza el tamaño de los valores destacados en las cards de detalle (Tasa de Preñez, ADG Promedio, Peso Biológico), que usaban un font-size inline al doble (3rem) del resto de KPIs (1.5rem/.h1). Se alinea también el peso de fuente del subheader "Tasa de Preñez Global" con el resto.

- Modo oscuro/claro: corrige 3 bugs de theming encontrados en auditoría — (1) el ícono sol/luna del header nunca cambiaba porque ThemeService aplicaba data-bs-theme en <body> en vez de <html>, rompiendo el selector :root que usa Tabler; (2) flash inicial oscuro→claro por un default hardcodeado en index.html que no coincidía con el default real del servicio; (3) las gráficas ApexCharts tenían el tema fijo en 'dark' (o sin tema) de forma inconsistente entre dashboards, ignorando el toggle real. Las 4 gráficas del dashboard ahora reaccionan a ThemeService.currentTheme().

---------