### PR TITLE
Feature/Catálogos de Configuración ADMIN — Fase 0 (Raza) + Fase 1 (Etapas de Vida)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ n8n_backup/
 local-files/
 sync_dbs.sh
 
+# Excepción: las migraciones versionadas de agro-erp SÍ deben trackearse
+# (no son dumps/backups, son el historial de cambios de esquema del proyecto)
+!hosting3m-workspace/projects/agro-erp/database/migrations/*.sql
+
 # --- Node.js / Microservicios (General) ---
 node_modules/
 npm-debug.log*

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/001_salida_ganado_trazabilidad.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/001_salida_ganado_trazabilidad.sql
@@ -1,0 +1,103 @@
+-- Migration 001: Trazabilidad de salida de ganado (UPP, TB/BR, historico_movimientos, SP)
+-- Fase 1 del MVP de trazabilidad ganadera (Sprint 1 - 300 cabezas / UPP La Bendición, UPP 54)
+BEGIN;
+
+-- 1. Extensión de cattle_livestock (no se crea tabla nueva: se reutiliza electronic_rfid como bolo RFID)
+ALTER TABLE public.cattle_livestock
+    ADD COLUMN upp_origen character varying(100),
+    ADD COLUMN tb_test_date date,
+    ADD COLUMN br_test_date date;
+
+COMMENT ON COLUMN public.cattle_livestock.upp_origen IS 'Centro de costos/rancho de origen (ej. UPP La Bendición, UPP 54). Se pone en NULL cuando el animal sale (VENDIDO).';
+COMMENT ON COLUMN public.cattle_livestock.tb_test_date IS 'Fecha de última prueba de Tuberculosis. Vigencia normativa: 60 días.';
+COMMENT ON COLUMN public.cattle_livestock.br_test_date IS 'Fecha de última prueba de Brucelosis. Vigencia normativa: 60 días.';
+
+-- 2. Migración del CHECK de current_status: agrega CUARENTENA sin romper los 9 valores ya usados en producción
+ALTER TABLE public.cattle_livestock
+    DROP CONSTRAINT cattle_livestock_current_status_check;
+
+ALTER TABLE public.cattle_livestock
+ADD CONSTRAINT cattle_livestock_current_status_check
+CHECK (
+    current_status IN (
+        'ACTIVO',
+        'EN_TRANSITO',
+        'VENDIDO',
+        'BAJA_MORTANDAD',
+        'PREÑADA',
+        'VACÍA',
+        'DESARROLLO',
+        'RIESGO',
+        'FINALIZADO',
+        'CUARENTENA'
+    )
+);
+
+-- 3. Archivo histórico de movimientos (salidas/bajas/traslados)
+CREATE TABLE public.historico_movimientos (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    livestock_id uuid NOT NULL REFERENCES public.cattle_livestock(id),
+    electronic_rfid character varying(100) NOT NULL,
+    tenant_id integer NOT NULL,
+    tipo_movimiento character varying(50) NOT NULL,
+    upp_origen_anterior character varying(100),
+    fecha_registro timestamp without time zone DEFAULT now() NOT NULL,
+    CONSTRAINT historico_movimientos_tipo_check CHECK (
+        (tipo_movimiento)::text = ANY (ARRAY['VENTA', 'BAJA_MORTANDAD', 'TRASLADO']::text[])
+    )
+);
+
+CREATE INDEX idx_historico_movimientos_rfid ON public.historico_movimientos (electronic_rfid);
+CREATE INDEX idx_historico_movimientos_livestock ON public.historico_movimientos (livestock_id);
+
+-- 4. Stored Procedure atómico de salida de ganado
+-- Nota ACID: al ser una función plpgsql invocada dentro de una transacción implícita,
+-- cualquier RAISE EXCEPTION revierte automáticamente el UPDATE + INSERT ya ejecutados
+-- en esta misma llamada (no se necesita ROLLBACK explícito ni bloque EXCEPTION que lo capture).
+CREATE OR REPLACE FUNCTION public.sp_procesar_salida_ganado(p_electronic_rfid character varying)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_livestock_id   uuid;
+    v_tenant_id      integer;
+    v_current_status character varying(50);
+    v_upp_anterior   character varying(100);
+BEGIN
+    -- FOR UPDATE bloquea la fila para evitar doble procesamiento por lecturas RFID concurrentes
+    SELECT id, tenant_id, current_status, upp_origen
+      INTO v_livestock_id, v_tenant_id, v_current_status, v_upp_anterior
+      FROM public.cattle_livestock
+     WHERE electronic_rfid = p_electronic_rfid
+       FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'RFID % no está registrado en el inventario', p_electronic_rfid
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    IF v_current_status = 'VENDIDO' THEN
+        RAISE EXCEPTION 'El animal con RFID % ya fue procesado como VENDIDO', p_electronic_rfid
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    UPDATE public.cattle_livestock
+       SET current_status = 'VENDIDO',
+           upp_origen = NULL
+     WHERE id = v_livestock_id;
+
+    INSERT INTO public.historico_movimientos
+        (livestock_id, electronic_rfid, tenant_id, tipo_movimiento, upp_origen_anterior)
+    VALUES
+        (v_livestock_id, p_electronic_rfid, v_tenant_id, 'VENTA', v_upp_anterior);
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'livestock_id', v_livestock_id,
+        'electronic_rfid', p_electronic_rfid,
+        'current_status', 'VENDIDO'
+    );
+END;
+$$;
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/002_sp_procesar_salida_ganado_normativa.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/002_sp_procesar_salida_ganado_normativa.sql
@@ -1,0 +1,83 @@
+-- Migration 002: Agrega validación normativa (TB/BR <= 60 días) a sp_procesar_salida_ganado.
+-- No cambia firma ni forma de invocación: sigue siendo SELECT sp_procesar_salida_ganado(p_electronic_rfid).
+-- Rechazo normativo = respuesta normal con success:false (NO excepción), para que el endpoint
+-- pueda distinguir "rechazo de negocio" (dispara alerta WhatsApp en Fase 5) de un error real de datos
+-- (RFID no encontrado / ya vendido, que sí siguen usando RAISE EXCEPTION).
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.sp_procesar_salida_ganado(p_electronic_rfid character varying)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_livestock_id   uuid;
+    v_tenant_id      integer;
+    v_current_status character varying(50);
+    v_upp_anterior   character varying(100);
+    v_tb_test_date   date;
+    v_br_test_date   date;
+    v_dias_tb        integer;
+    v_dias_br        integer;
+    v_motivo         text := '';
+BEGIN
+    -- FOR UPDATE bloquea la fila para evitar doble procesamiento por lecturas RFID concurrentes
+    SELECT id, tenant_id, current_status, upp_origen, tb_test_date, br_test_date
+      INTO v_livestock_id, v_tenant_id, v_current_status, v_upp_anterior, v_tb_test_date, v_br_test_date
+      FROM public.cattle_livestock
+     WHERE electronic_rfid = p_electronic_rfid
+       FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'RFID % no está registrado en el inventario', p_electronic_rfid
+            USING ERRCODE = 'P0002';
+    END IF;
+
+    IF v_current_status = 'VENDIDO' THEN
+        RAISE EXCEPTION 'El animal con RFID % ya fue procesado como VENDIDO', p_electronic_rfid
+            USING ERRCODE = 'P0001';
+    END IF;
+
+    -- Validación normativa: rechazo de negocio, no de datos.
+    v_dias_tb := CASE WHEN v_tb_test_date IS NULL THEN NULL ELSE CURRENT_DATE - v_tb_test_date END;
+    v_dias_br := CASE WHEN v_br_test_date IS NULL THEN NULL ELSE CURRENT_DATE - v_br_test_date END;
+
+    IF v_tb_test_date IS NULL OR v_dias_tb > 60 THEN
+        v_motivo := v_motivo || 'Prueba TB ' ||
+            (CASE WHEN v_tb_test_date IS NULL THEN 'no registrada. ' ELSE 'vencida hace ' || v_dias_tb || ' días. ' END);
+    END IF;
+
+    IF v_br_test_date IS NULL OR v_dias_br > 60 THEN
+        v_motivo := v_motivo || 'Prueba Brucelosis ' ||
+            (CASE WHEN v_br_test_date IS NULL THEN 'no registrada. ' ELSE 'vencida hace ' || v_dias_br || ' días. ' END);
+    END IF;
+
+    IF v_motivo <> '' THEN
+        RETURN jsonb_build_object(
+            'success', false,
+            'livestock_id', v_livestock_id,
+            'electronic_rfid', p_electronic_rfid,
+            'current_status', v_current_status,
+            'motivo', trim(v_motivo)
+        );
+    END IF;
+
+    UPDATE public.cattle_livestock
+       SET current_status = 'VENDIDO',
+           upp_origen = NULL
+     WHERE id = v_livestock_id;
+
+    INSERT INTO public.historico_movimientos
+        (livestock_id, electronic_rfid, tenant_id, tipo_movimiento, upp_origen_anterior)
+    VALUES
+        (v_livestock_id, p_electronic_rfid, v_tenant_id, 'VENTA', v_upp_anterior);
+
+    RETURN jsonb_build_object(
+        'success', true,
+        'livestock_id', v_livestock_id,
+        'electronic_rfid', p_electronic_rfid,
+        'current_status', 'VENDIDO'
+    );
+END;
+$$;
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/003_crud_models_salida_ganado.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/003_crud_models_salida_ganado.sql
@@ -1,0 +1,27 @@
+-- Migration 003: Registra el modelo 'salida_ganado' en crud_models para exponer
+-- sp_procesar_salida_ganado a través del gateway genérico (case 'call_sp' en Build Query).
+-- Ya ejecutada manualmente (id=46). Este archivo documenta el cambio para mantener
+-- el repo en sync con el estado real de la base de datos.
+BEGIN;
+
+INSERT INTO public.crud_models (
+    model_name, table_name, primary_key,
+    allowed_fields, schema_json, allowed_ops,
+    allowed_roles_select, allowed_roles_insert, allowed_roles_update, allowed_roles_delete,
+    joins, hooks
+) VALUES (
+    'salida_ganado',
+    'sp_procesar_salida_ganado',
+    'electronic_rfid',
+    '["electronic_rfid"]'::jsonb,
+    '{"electronic_rfid": {"type": "text", "required": true}}'::jsonb,
+    '{INSERT}'::text[],
+    'ADMIN,EDITOR',
+    'ADMIN,EDITOR',
+    'ADMIN',
+    'ADMIN',
+    '[]'::jsonb,
+    '{"pre": [], "post": []}'::jsonb
+);
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/004_vw_cattle_kpi_add_salida_fields.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/004_vw_cattle_kpi_add_salida_fields.sql
@@ -1,0 +1,48 @@
+-- Migration 004 (v2): vw_cattle_kpi no incluía upp_origen/tb_test_date/br_test_date
+-- porque la vista lista columnas explícitas (no SELECT cl.*) y fue creada antes
+-- de la Fase 1. CREATE OR REPLACE VIEW exige que las columnas existentes se
+-- conserven en el mismo nombre/orden; las nuevas solo pueden agregarse al final.
+--
+-- v2: la v1 de esta migración fallaba con
+--   ERROR: cannot change name of view column "species" to "upp_origen"
+-- porque la vista en producción ya tenía una 17a columna (`species`) que esta
+-- migración no contemplaba. Se verificó el orden real vía:
+--   SELECT ordinal_position, column_name FROM information_schema.columns
+--   WHERE table_schema='public' AND table_name='vw_cattle_kpi' ORDER BY 1;
+-- y se ajustó el SELECT list para preservar esas 17 columnas y anexar las 3
+-- nuevas (upp_origen, tb_test_date, br_test_date) en las posiciones 18-20.
+BEGIN;
+
+CREATE OR REPLACE VIEW public.vw_cattle_kpi AS
+ SELECT cl.id,
+    cl.tenant_id,
+    cl.rfid_siniiga,
+    cl.business_model,
+    cl.category,
+    cl.current_status,
+    cl.birth_date,
+    cl.current_weight_kg,
+    cl.metadata,
+    cl.created_at,
+    cl.electronic_rfid,
+    cl.numero_fuego,
+    c.company_name AS tenant_name,
+    round((cl.current_weight_kg / ((CURRENT_DATE - cl.birth_date))::numeric), 2) AS adg_lifetime_kg,
+    ( SELECT (hl.medicines_json ->> 'resultado'::text)
+           FROM public.cattle_health_logs hl
+          WHERE ((hl.livestock_id = cl.id) AND ((hl.event_type)::text = 'PALPACION'::text))
+          ORDER BY hl.event_date DESC
+         LIMIT 1) AS last_palpation_result,
+    ( SELECT ((hl.medicines_json ->> 'dias_gestacion'::text))::integer AS int4
+           FROM public.cattle_health_logs hl
+          WHERE ((hl.livestock_id = cl.id) AND ((hl.event_type)::text = 'PALPACION'::text))
+          ORDER BY hl.event_date DESC
+         LIMIT 1) AS current_gestation_days,
+    cl.species,
+    cl.upp_origen,
+    cl.tb_test_date,
+    cl.br_test_date
+   FROM (public.cattle_livestock cl
+     LEFT JOIN public.companys c ON ((cl.tenant_id = c.id_company)));
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/005_add_novillona_category.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/005_add_novillona_category.sql
@@ -1,0 +1,19 @@
+-- Migration 005: Agrega NOVILLONA al CHECK de cattle_livestock.category (jerarquía
+-- Becerra -> Novillona -> Vaca confirmada por el cliente). category es VARCHAR + CHECK,
+-- no un ENUM nativo, por lo que el fix es DROP + ADD CONSTRAINT (mismo patrón que la
+-- migración 001 usó para agregar CUARENTENA a current_status).
+BEGIN;
+
+ALTER TABLE public.cattle_livestock
+    DROP CONSTRAINT cattle_livestock_category_check;
+
+ALTER TABLE public.cattle_livestock
+ADD CONSTRAINT cattle_livestock_category_check
+CHECK (
+    category IN (
+        'VACA','TORO','NOVILLO','NOVILLONA','BECERRA','BECERRO',
+        'BUFALA','BUFALO','BUCERRO','BUCERRA','BORREGO','BORREGA'
+    )
+);
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/006_cattle_breed_catalog.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/006_cattle_breed_catalog.sql
@@ -1,0 +1,37 @@
+-- Migration 006: Catálogo GLOBAL (sin tenant_id) de estándares zootécnicos por raza
+-- (Fase 0 de Etapas de Vida / Protocolo Sanitario). Pesos objetivo, % peso primer
+-- servicio y días de gestación son estándar zootécnico, no varían por rancho.
+-- especie sigue el mismo patrón que cattle_livestock.species/category: VARCHAR + CHECK,
+-- no una FK a un catálogo de especies que no existe en el esquema.
+BEGIN;
+
+CREATE TABLE public.cattle_breed_catalog (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    especie character varying NOT NULL,
+    raza_grupo character varying NOT NULL,
+    raza_variante character varying,
+    peso_adulto_hembra_kg numeric(10,2) NOT NULL,
+    peso_adulto_macho_kg numeric(10,2) NOT NULL,
+    pct_peso_primer_servicio numeric(5,2) NOT NULL DEFAULT 65.00,
+    edad_min_pubertad_meses numeric(5,1),
+    dias_gestacion_promedio integer NOT NULL,
+    created_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT cattle_breed_catalog_especie_check
+        CHECK (especie IN ('BOVINO','BUFALO','BORREGO')),
+    CONSTRAINT cattle_breed_catalog_peso_hembra_check CHECK (peso_adulto_hembra_kg > 0),
+    CONSTRAINT cattle_breed_catalog_peso_macho_check CHECK (peso_adulto_macho_kg > 0),
+    CONSTRAINT cattle_breed_catalog_pct_servicio_check
+        CHECK (pct_peso_primer_servicio > 0 AND pct_peso_primer_servicio <= 100),
+    CONSTRAINT uq_breed_especie_grupo_variante UNIQUE (especie, raza_grupo, raza_variante)
+);
+
+-- Gotcha de Postgres: UNIQUE no detecta duplicados cuando raza_variante es NULL
+-- (NULL <> NULL). Este índice parcial cubre el caso "raza sin subdivisión".
+CREATE UNIQUE INDEX uq_breed_sin_variante
+    ON public.cattle_breed_catalog (especie, raza_grupo)
+    WHERE raza_variante IS NULL;
+
+COMMENT ON TABLE public.cattle_breed_catalog IS 'Catálogo GLOBAL (sin tenant_id) de estándares zootécnicos por raza. Editable exclusivamente por ADMIN vía Meta-CRUD.';
+COMMENT ON COLUMN public.cattle_breed_catalog.edad_min_pubertad_meses IS 'Orientativo, nunca determinante para decisiones automatizadas.';
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/007_crud_models_breed_catalog.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/007_crud_models_breed_catalog.sql
@@ -1,0 +1,25 @@
+-- Migration 007: Registra el modelo 'cattle_breed_catalog' en crud_models para exponerlo
+-- a través del gateway Meta-CRUD (archivo separado del DDL, mismo patrón que
+-- 003_crud_models_salida_ganado.sql registró 'salida_ganado' aparte de su tabla).
+-- ADMIN exclusivo en las 4 operaciones de escritura/lectura: catálogo de configuración,
+-- no dato operativo de campo.
+BEGIN;
+
+INSERT INTO public.crud_models (
+    model_name, table_name, primary_key,
+    allowed_fields, schema_json, allowed_ops,
+    allowed_roles_select, allowed_roles_insert, allowed_roles_update, allowed_roles_delete,
+    joins, hooks
+) VALUES (
+    'cattle_breed_catalog',
+    'cattle_breed_catalog',
+    'id',
+    '["id","especie","raza_grupo","raza_variante","peso_adulto_hembra_kg","peso_adulto_macho_kg","pct_peso_primer_servicio","edad_min_pubertad_meses","dias_gestacion_promedio","created_at"]'::jsonb,
+    '{"id": {"type":"text","required":false}, "especie": {"type":"text","required":true}, "raza_grupo": {"type":"text","required":true}, "raza_variante": {"type":"text","required":false}, "peso_adulto_hembra_kg": {"type":"number","required":true}, "peso_adulto_macho_kg": {"type":"number","required":true}, "pct_peso_primer_servicio": {"type":"number","required":false}, "edad_min_pubertad_meses": {"type":"number","required":false}, "dias_gestacion_promedio": {"type":"number","required":true}}'::jsonb,
+    '{SELECT,INSERT,UPDATE,DELETE,GETONE,GETALL}'::text[],
+    'ADMIN', 'ADMIN', 'ADMIN', 'ADMIN',
+    '[]'::jsonb,
+    '{"pre": [], "post": []}'::jsonb
+);
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/008_cattle_lifestage_catalog.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/008_cattle_lifestage_catalog.sql
@@ -1,0 +1,41 @@
+-- Migration 008: Catálogo GLOBAL (sin tenant_id) de transiciones de etapa de vida por
+-- especie (Fase 1 de Etapas de Vida / Protocolo Sanitario). No implementa todavía la
+-- lógica que dispare o valide transiciones reales contra cattle_livestock (fase futura).
+-- especie/categoria_origen/categoria_destino siguen el mismo patrón VARCHAR+CHECK ya
+-- usado en cattle_livestock.category/species y cattle_breed_catalog.especie.
+BEGIN;
+
+CREATE TABLE public.cattle_lifestage_catalog (
+    id uuid DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    especie character varying NOT NULL,
+    categoria_origen character varying NOT NULL,
+    categoria_destino character varying NOT NULL,
+    edad_min_meses numeric(5,1) NOT NULL,
+    requiere_validacion_peso boolean NOT NULL DEFAULT true,
+    notas text,
+    created_at timestamp without time zone DEFAULT now(),
+    CONSTRAINT cattle_lifestage_catalog_especie_check
+        CHECK (especie IN ('BOVINO','BUFALO','BORREGO')),
+    CONSTRAINT cattle_lifestage_catalog_categoria_origen_check
+        CHECK (categoria_origen IN ('VACA','TORO','NOVILLO','NOVILLONA','BECERRA','BECERRO','BUFALA','BUFALO','BUCERRO','BUCERRA','BORREGO','BORREGA')),
+    CONSTRAINT cattle_lifestage_catalog_categoria_destino_check
+        CHECK (categoria_destino IN ('VACA','TORO','NOVILLO','NOVILLONA','BECERRA','BECERRO','BUFALA','BUFALO','BUCERRO','BUCERRA','BORREGO','BORREGA')),
+    CONSTRAINT cattle_lifestage_catalog_no_self_transition_check
+        CHECK (categoria_origen <> categoria_destino),
+    CONSTRAINT cattle_lifestage_catalog_edad_min_check CHECK (edad_min_meses > 0),
+    CONSTRAINT uq_lifestage_especie_origen_destino UNIQUE (especie, categoria_origen, categoria_destino)
+);
+
+COMMENT ON TABLE public.cattle_lifestage_catalog IS 'Catálogo GLOBAL (sin tenant_id) de transiciones de etapa de vida por especie. edad_min_meses es orientativa: dispara revisión, nunca promueve la categoría por sí sola. Editable exclusivamente por ADMIN vía Meta-CRUD.';
+COMMENT ON COLUMN public.cattle_lifestage_catalog.requiere_validacion_peso IS 'Si true, la transición real además exige que el peso del animal alcance pct_peso_primer_servicio de cattle_breed_catalog para su raza. Si false, la transición es solo por edad (ej. destete).';
+
+-- Seed confirmado por el cliente. Solo BOVINO por ahora — Búfalo/Borrego NO se insertan
+-- todavía (pendientes de confirmación), no se usan filas NULL de relleno.
+INSERT INTO public.cattle_lifestage_catalog
+    (especie, categoria_origen, categoria_destino, edad_min_meses, requiere_validacion_peso) VALUES
+    ('BOVINO', 'BECERRA',   'NOVILLONA', 7,  false),
+    ('BOVINO', 'NOVILLONA', 'VACA',      19, true),
+    ('BOVINO', 'BECERRO',   'NOVILLO',   7,  false),
+    ('BOVINO', 'NOVILLO',   'TORO',      19, true);
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/009_crud_models_lifestage_catalog.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/009_crud_models_lifestage_catalog.sql
@@ -1,0 +1,23 @@
+-- Migration 009: Registra el modelo 'cattle_lifestage_catalog' en crud_models (archivo
+-- separado del DDL, mismo patrón que 007_crud_models_breed_catalog.sql). ADMIN exclusivo
+-- en las 4 operaciones: catálogo de configuración, no dato operativo de campo.
+BEGIN;
+
+INSERT INTO public.crud_models (
+    model_name, table_name, primary_key,
+    allowed_fields, schema_json, allowed_ops,
+    allowed_roles_select, allowed_roles_insert, allowed_roles_update, allowed_roles_delete,
+    joins, hooks
+) VALUES (
+    'cattle_lifestage_catalog',
+    'cattle_lifestage_catalog',
+    'id',
+    '["id","especie","categoria_origen","categoria_destino","edad_min_meses","requiere_validacion_peso","notas","created_at"]'::jsonb,
+    '{"id": {"type":"text","required":false}, "especie": {"type":"text","required":true}, "categoria_origen": {"type":"text","required":true}, "categoria_destino": {"type":"text","required":true}, "edad_min_meses": {"type":"number","required":true}, "requiere_validacion_peso": {"type":"boolean","required":false}, "notas": {"type":"text","required":false}}'::jsonb,
+    '{SELECT,INSERT,UPDATE,DELETE,GETONE,GETALL}'::text[],
+    'ADMIN', 'ADMIN', 'ADMIN', 'ADMIN',
+    '[]'::jsonb,
+    '{"pre": [], "post": []}'::jsonb
+);
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/src/app/core/models/breed-catalog.model.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/core/models/breed-catalog.model.ts
@@ -1,0 +1,12 @@
+export interface BreedCatalog {
+  id?: string;
+  especie: 'BOVINO' | 'BUFALO' | 'BORREGO';
+  raza_grupo: string;
+  raza_variante?: string;
+  peso_adulto_hembra_kg: number;
+  peso_adulto_macho_kg: number;
+  pct_peso_primer_servicio: number;
+  edad_min_pubertad_meses?: number;
+  dias_gestacion_promedio: number;
+  created_at?: string;
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/core/models/lifestage-catalog.model.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/core/models/lifestage-catalog.model.ts
@@ -1,0 +1,10 @@
+export interface LifestageCatalog {
+  id?: string;
+  especie: 'BOVINO' | 'BUFALO' | 'BORREGO';
+  categoria_origen: string;
+  categoria_destino: string;
+  edad_min_meses: number;
+  requiere_validacion_peso: boolean;
+  notas?: string;
+  created_at?: string;
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/admin.routes.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/admin.routes.ts
@@ -17,5 +17,10 @@ export const adminRoutes: Routes = [
         canActivate: [roleGuard(['ADMIN'])],
         loadComponent: () => import('./components/breed-catalog/breed-catalog.component').then(m => m.BreedCatalogComponent)
     },
+    {
+        path: 'etapas-vida',
+        canActivate: [roleGuard(['ADMIN'])],
+        loadComponent: () => import('./components/lifestage-catalog/lifestage-catalog.component').then(m => m.LifestageCatalogComponent)
+    },
     { path: '', redirectTo: 'tenants', pathMatch: 'full' }
 ];

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/admin.routes.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/admin.routes.ts
@@ -12,5 +12,10 @@ export const adminRoutes: Routes = [
         canActivate: [roleGuard(['ADMIN'])],
         loadComponent: () => import('./components/user-list/user-list.component').then(m => m.UserListComponent)
     },
+    {
+        path: 'razas',
+        canActivate: [roleGuard(['ADMIN'])],
+        loadComponent: () => import('./components/breed-catalog/breed-catalog.component').then(m => m.BreedCatalogComponent)
+    },
     { path: '', redirectTo: 'tenants', pathMatch: 'full' }
 ];

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-catalog/breed-catalog.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-catalog/breed-catalog.component.html
@@ -1,0 +1,101 @@
+<div class="container-fluid p-3 p-md-4 animate__animated animate__fadeIn">
+
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="d-flex align-items-center gap-3">
+            <div class="d-none d-md-block">
+                <span class="bg-green-lt p-2 rounded-3"><i class="ti ti-dna fs-2"></i></span>
+            </div>
+            <div>
+                <h2 class="page-title mb-0">Catálogo de Raza</h2>
+                <div class="text-muted small mt-1">Estándares zootécnicos globales por raza (pesos objetivo, gestación)</div>
+            </div>
+        </div>
+        <div>
+            <button class="btn btn-primary shadow-sm" (click)="openModal()">
+                <i class="ti ti-square-rounded-plus me-2"></i>
+                <span class="d-none d-sm-inline">Nueva Raza</span>
+                <span class="d-inline d-sm-none">Nueva</span>
+            </button>
+        </div>
+    </div>
+
+    <div class="row g-2 mb-3 align-items-center">
+        <div class="col-12 col-md-8">
+            <div class="input-group">
+                <span class="input-group-text bg-white border-end-0">
+                    <i class="ti ti-search text-muted"></i>
+                </span>
+                <input type="text" class="form-control border-start-0"
+                    placeholder="Buscar por grupo o variante de raza..."
+                    [ngModel]="searchQuery()" (ngModelChange)="searchQuery.set($event)">
+            </div>
+        </div>
+        <div class="col-12 col-md-4 text-muted small text-end">
+            {{ filteredBreeds().length }} / {{ breeds().length }} razas
+        </div>
+    </div>
+
+    <div class="row row-cards">
+        @for (breed of filteredBreeds(); track breed.id) {
+        <div class="col-12 col-md-6 col-xl-4">
+            <div class="card shadow-sm border-0 h-100 hover-shadow-lg transition-all">
+                <div class="card-body p-3">
+                    <div class="d-flex align-items-center mb-2">
+                        <span class="avatar avatar-md me-3 bg-green-lt text-uppercase fw-bold rounded shadow-sm">
+                            {{ breed.especie.charAt(0) }}
+                        </span>
+                        <div class="flex-fill overflow-hidden">
+                            <div class="font-weight-medium fs-4 text-truncate mb-1">
+                                {{ breed.raza_grupo }}
+                            </div>
+                            @if (breed.raza_variante) {
+                            <div class="text-muted fs-5 text-truncate">{{ breed.raza_variante }}</div>
+                            }
+                        </div>
+                        <div class="ms-2 d-flex flex-column gap-1">
+                            <button class="btn btn-icon btn-outline-secondary btn-sm" (click)="openModal(breed)"
+                                [disabled]="isLoadingDetail()" title="Editar Raza">
+                                <i class="ti ti-edit"></i>
+                            </button>
+                            <button class="btn btn-icon btn-outline-danger btn-sm" (click)="deleteBreed(breed)"
+                                title="Eliminar Raza">
+                                <i class="ti ti-trash"></i>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="mb-2">
+                        <span class="badge bg-orange-lt">{{ breed.especie }}</span>
+                        <span class="badge bg-blue-lt ms-1">{{ breed.dias_gestacion_promedio }} días gestación</span>
+                    </div>
+
+                    <div class="row text-muted fs-5">
+                        <div class="col-6">
+                            <i class="ti ti-gender-female me-1"></i> {{ breed.peso_adulto_hembra_kg | number:'1.0-0' }} kg
+                        </div>
+                        <div class="col-6">
+                            <i class="ti ti-gender-male me-1"></i> {{ breed.peso_adulto_macho_kg | number:'1.0-0' }} kg
+                        </div>
+                    </div>
+                </div>
+                <div class="card-progress-bottom" style="background-color: #2fb344;"></div>
+            </div>
+        </div>
+        } @empty {
+        <div class="col-12 text-center py-5">
+            <div class="empty-state">
+                <div class="empty-img"><i class="ti ti-dna-off fs-1 text-muted"></i></div>
+                <p class="empty-title fs-3">No hay razas registradas</p>
+                <p class="empty-subtitle text-muted">Da de alta la primera raza para comenzar a estandarizar el catálogo.</p>
+                <button class="btn btn-primary mt-3" (click)="openModal()">
+                    <i class="ti ti-square-rounded-plus me-2"></i> Nueva Raza
+                </button>
+            </div>
+        </div>
+        }
+    </div>
+</div>
+
+<app-breed-form-modal [isOpen]="isModalOpen()" [selectedBreed]="selectedBreed()" [isReadonly]="isReadOnlyMode()"
+    [(breedData)]="currentBreedData" (onClose)="closeModal()" (onSave)="saveBreed()">
+</app-breed-form-modal>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-catalog/breed-catalog.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-catalog/breed-catalog.component.ts
@@ -1,0 +1,107 @@
+import { Component, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { lastValueFrom } from 'rxjs';
+import { AdminService } from '@features/admin/services/admin.service';
+import { BreedCatalog } from '@core/models/breed-catalog.model';
+import { BreedFormModalComponent } from '../breed-form-modal/breed-form-modal.component';
+
+@Component({
+  selector: 'app-breed-catalog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, BreedFormModalComponent],
+  templateUrl: './breed-catalog.component.html',
+})
+export class BreedCatalogComponent {
+  public adminService = inject(AdminService);
+
+  breeds = this.adminService.breeds;
+  loadingBreeds = this.adminService.loadingBreeds;
+
+  searchQuery = signal<string>('');
+
+  filteredBreeds = computed(() => {
+    const q = this.searchQuery().toLowerCase();
+    return this.breeds().filter(b =>
+      !q ||
+      b.raza_grupo?.toLowerCase().includes(q) ||
+      b.raza_variante?.toLowerCase().includes(q) ||
+      b.especie?.toLowerCase().includes(q)
+    );
+  });
+
+  isModalOpen = signal<boolean>(false);
+  isLoadingDetail = signal<boolean>(false);
+  isReadOnlyMode = signal<boolean>(false);
+  selectedBreed = signal<BreedCatalog | null>(null);
+  currentBreedData = signal<Partial<BreedCatalog>>({});
+
+  constructor() {
+    this.adminService.loadBreeds();
+  }
+
+  openModal(breed: BreedCatalog | null = null) {
+    this.isReadOnlyMode.set(false);
+    if (breed) {
+      this.selectedBreed.set(breed);
+      this.currentBreedData.set({ ...breed });
+    } else {
+      this.selectedBreed.set(null);
+      this.currentBreedData.set(this.getEmptyBreed());
+    }
+    this.isModalOpen.set(true);
+  }
+
+  closeModal() {
+    this.isModalOpen.set(false);
+    this.selectedBreed.set(null);
+  }
+
+  async saveBreed() {
+    const data = this.currentBreedData();
+    const operation: 'insert' | 'update' = this.selectedBreed() ? 'update' : 'insert';
+
+    if (!data.especie || !data.raza_grupo || !data.peso_adulto_hembra_kg || !data.peso_adulto_macho_kg || !data.dias_gestacion_promedio) {
+      alert('⚠️ Especie, Grupo de Raza, Pesos Adultos y Días de Gestación son obligatorios.');
+      return;
+    }
+
+    try {
+      await lastValueFrom(
+        this.adminService.saveBreed(data, operation, this.selectedBreed()?.id)
+      );
+      alert(operation === 'insert' ? '✅ Raza registrada correctamente' : '✅ Raza actualizada correctamente');
+      this.closeModal();
+      this.adminService.loadBreeds();
+    } catch (error) {
+      console.error('[Agro-ERP] Error al guardar la raza:', error);
+      alert('❌ Error al guardar el registro en la base de datos.');
+    }
+  }
+
+  async deleteBreed(breed: BreedCatalog) {
+    const label = `${breed.raza_grupo}${breed.raza_variante ? ' — ' + breed.raza_variante : ''}`;
+    if (!confirm(`⚠️ ¿Eliminar la raza "${label}" del catálogo? Esta acción no puede deshacerse.`)) return;
+
+    try {
+      await lastValueFrom(this.adminService.deleteBreed(breed.id!));
+      this.adminService.loadBreeds();
+    } catch (error) {
+      console.error('[Agro-ERP] Error al eliminar la raza:', error);
+      alert('❌ No se pudo eliminar el registro.');
+    }
+  }
+
+  private getEmptyBreed(): Partial<BreedCatalog> {
+    return {
+      especie: 'BOVINO',
+      raza_grupo: '',
+      raza_variante: '',
+      peso_adulto_hembra_kg: undefined,
+      peso_adulto_macho_kg: undefined,
+      pct_peso_primer_servicio: 65.00,
+      edad_min_pubertad_meses: undefined,
+      dias_gestacion_promedio: undefined,
+    };
+  }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-form-modal/breed-form-modal.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-form-modal/breed-form-modal.component.html
@@ -1,0 +1,105 @@
+@if (isOpen()) {
+<div class="modal-backdrop fade show"></div>
+<div class="modal modal-blur fade show d-block" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content shadow-lg border-0">
+            <div class="modal-header bg-dark text-white">
+                <h5 class="modal-title">
+                    <i class="ti ti-dna me-2"></i>
+                    @if (isReadonly()) {
+                    Detalle de la Raza
+                    } @else {
+                    {{ selectedBreed() ? 'Actualizar Raza del Catálogo' : 'Alta de Nueva Raza' }}
+                    }
+                </h5>
+                <button type="button" class="btn-close btn-close-white" (click)="onClose.emit()"></button>
+            </div>
+            <div class="modal-body p-4">
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Especie <span class="text-danger">*</span></label>
+                        <select class="form-select shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().especie" (ngModelChange)="updateField('especie', $event)">
+                            <option value="BOVINO">Bovino</option>
+                            <option value="BUFALO">Búfalo</option>
+                            <option value="BORREGO">Borrego</option>
+                        </select>
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Días de Gestación Promedio <span class="text-danger">*</span></label>
+                        <input type="number" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().dias_gestacion_promedio"
+                            (ngModelChange)="updateField('dias_gestacion_promedio', $event)"
+                            placeholder="Ej. 285">
+                    </div>
+                </div>
+
+                <hr class="my-4">
+                <h6 class="text-muted text-uppercase fw-bold mb-3">Identificación de la Raza</h6>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Grupo de Raza <span class="text-danger">*</span></label>
+                        <input type="text" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().raza_grupo" (ngModelChange)="updateField('raza_grupo', $event)"
+                            placeholder="Ej. Cebú">
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Variante</label>
+                        <input type="text" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().raza_variante" (ngModelChange)="updateField('raza_variante', $event)"
+                            placeholder="Ej. Brahman, Nelore, Puro, Cruza">
+                    </div>
+                </div>
+
+                <hr class="my-4">
+                <h6 class="text-muted text-uppercase fw-bold mb-3">Estándares Zootécnicos</h6>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Peso Adulto Hembra (kg) <span class="text-danger">*</span></label>
+                        <input type="number" step="0.01" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().peso_adulto_hembra_kg"
+                            (ngModelChange)="updateField('peso_adulto_hembra_kg', $event)"
+                            placeholder="Ej. 450.00">
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Peso Adulto Macho (kg) <span class="text-danger">*</span></label>
+                        <input type="number" step="0.01" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().peso_adulto_macho_kg"
+                            (ngModelChange)="updateField('peso_adulto_macho_kg', $event)"
+                            placeholder="Ej. 750.00">
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">% Peso Primer Servicio</label>
+                        <input type="number" step="0.01" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().pct_peso_primer_servicio"
+                            (ngModelChange)="updateField('pct_peso_primer_servicio', $event)"
+                            placeholder="Ej. 65.00">
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Edad Mínima Pubertad (meses)</label>
+                        <input type="number" step="0.1" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="breedData().edad_min_pubertad_meses"
+                            (ngModelChange)="updateField('edad_min_pubertad_meses', $event)"
+                            placeholder="Orientativo, nunca determinante">
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary px-4 shadow-sm" (click)="onClose.emit()">
+                    {{ isReadonly() ? 'Cerrar' : 'Cancelar' }}
+                </button>
+                @if (!isReadonly()) {
+                <button class="btn btn-success px-4 shadow-sm" (click)="onSave.emit()">
+                    <i class="ti ti-device-floppy me-2"></i> Guardar Cambios
+                </button>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-form-modal/breed-form-modal.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/breed-form-modal/breed-form-modal.component.ts
@@ -1,0 +1,24 @@
+import { CommonModule } from '@angular/common';
+import { Component, input, model, output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BreedCatalog } from '@core/models/breed-catalog.model';
+
+@Component({
+  selector: 'app-breed-form-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './breed-form-modal.component.html',
+})
+export class BreedFormModalComponent {
+  isOpen = input.required<boolean>();
+  selectedBreed = input<BreedCatalog | null>(null);
+  isReadonly = input<boolean>(false);
+  breedData = model.required<Partial<BreedCatalog>>();
+
+  onClose = output<void>();
+  onSave = output<void>();
+
+  updateField(key: string, value: any) {
+    this.breedData.update(current => ({ ...current, [key]: value }));
+  }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-catalog/lifestage-catalog.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-catalog/lifestage-catalog.component.html
@@ -1,0 +1,98 @@
+<div class="container-fluid p-3 p-md-4 animate__animated animate__fadeIn">
+
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="d-flex align-items-center gap-3">
+            <div class="d-none d-md-block">
+                <span class="bg-blue-lt p-2 rounded-3"><i class="ti ti-arrow-right fs-2"></i></span>
+            </div>
+            <div>
+                <h2 class="page-title mb-0">Etapas de Vida</h2>
+                <div class="text-muted small mt-1">Transiciones de categoría por especie (edad orientativa, nunca determinante)</div>
+            </div>
+        </div>
+        <div>
+            <button class="btn btn-primary shadow-sm" (click)="openModal()">
+                <i class="ti ti-square-rounded-plus me-2"></i>
+                <span class="d-none d-sm-inline">Nueva Transición</span>
+                <span class="d-inline d-sm-none">Nueva</span>
+            </button>
+        </div>
+    </div>
+
+    <div class="row g-2 mb-3 align-items-center">
+        <div class="col-12 col-md-8">
+            <div class="input-group">
+                <span class="input-group-text bg-white border-end-0">
+                    <i class="ti ti-search text-muted"></i>
+                </span>
+                <input type="text" class="form-control border-start-0"
+                    placeholder="Buscar por categoría origen o destino..."
+                    [ngModel]="searchQuery()" (ngModelChange)="searchQuery.set($event)">
+            </div>
+        </div>
+        <div class="col-12 col-md-4 text-muted small text-end">
+            {{ filteredLifestages().length }} / {{ lifestages().length }} transiciones
+        </div>
+    </div>
+
+    <div class="row row-cards">
+        @for (lifestage of filteredLifestages(); track lifestage.id) {
+        <div class="col-12 col-md-6 col-xl-4">
+            <div class="card shadow-sm border-0 h-100 hover-shadow-lg transition-all">
+                <div class="card-body p-3">
+                    <div class="d-flex align-items-center mb-2">
+                        <span class="avatar avatar-md me-3 bg-blue-lt text-uppercase fw-bold rounded shadow-sm">
+                            {{ lifestage.especie.charAt(0) }}
+                        </span>
+                        <div class="flex-fill overflow-hidden">
+                            <div class="font-weight-medium fs-4 text-truncate mb-1">
+                                {{ lifestage.categoria_origen }} → {{ lifestage.categoria_destino }}
+                            </div>
+                            <div class="text-muted fs-5 text-truncate">{{ lifestage.edad_min_meses }} meses mínimo</div>
+                        </div>
+                        <div class="ms-2 d-flex flex-column gap-1">
+                            <button class="btn btn-icon btn-outline-secondary btn-sm" (click)="openModal(lifestage)"
+                                [disabled]="isLoadingDetail()" title="Editar Transición">
+                                <i class="ti ti-edit"></i>
+                            </button>
+                            <button class="btn btn-icon btn-outline-danger btn-sm" (click)="deleteLifestage(lifestage)"
+                                title="Eliminar Transición">
+                                <i class="ti ti-trash"></i>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="mb-2">
+                        <span class="badge bg-orange-lt">{{ lifestage.especie }}</span>
+                        @if (lifestage.requiere_validacion_peso) {
+                        <span class="badge bg-purple-lt ms-1">Requiere validación de peso</span>
+                        } @else {
+                        <span class="badge bg-secondary-lt ms-1">Solo por edad</span>
+                        }
+                    </div>
+
+                    @if (lifestage.notas) {
+                    <div class="text-muted fs-5 text-truncate">{{ lifestage.notas }}</div>
+                    }
+                </div>
+                <div class="card-progress-bottom" style="background-color: #206bc4;"></div>
+            </div>
+        </div>
+        } @empty {
+        <div class="col-12 text-center py-5">
+            <div class="empty-state">
+                <div class="empty-img"><i class="ti ti-arrow-right fs-1 text-muted"></i></div>
+                <p class="empty-title fs-3">No hay transiciones registradas</p>
+                <p class="empty-subtitle text-muted">Da de alta la primera transición para comenzar a estandarizar el catálogo.</p>
+                <button class="btn btn-primary mt-3" (click)="openModal()">
+                    <i class="ti ti-square-rounded-plus me-2"></i> Nueva Transición
+                </button>
+            </div>
+        </div>
+        }
+    </div>
+</div>
+
+<app-lifestage-form-modal [isOpen]="isModalOpen()" [selectedLifestage]="selectedLifestage()" [isReadonly]="isReadOnlyMode()"
+    [(lifestageData)]="currentLifestageData" (onClose)="closeModal()" (onSave)="saveLifestage()">
+</app-lifestage-form-modal>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-catalog/lifestage-catalog.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-catalog/lifestage-catalog.component.ts
@@ -1,0 +1,110 @@
+import { Component, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { lastValueFrom } from 'rxjs';
+import { AdminService } from '@features/admin/services/admin.service';
+import { LifestageCatalog } from '@core/models/lifestage-catalog.model';
+import { LifestageFormModalComponent } from '../lifestage-form-modal/lifestage-form-modal.component';
+
+@Component({
+  selector: 'app-lifestage-catalog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, LifestageFormModalComponent],
+  templateUrl: './lifestage-catalog.component.html',
+})
+export class LifestageCatalogComponent {
+  public adminService = inject(AdminService);
+
+  lifestages = this.adminService.lifestages;
+  loadingLifestages = this.adminService.loadingLifestages;
+
+  searchQuery = signal<string>('');
+
+  filteredLifestages = computed(() => {
+    const q = this.searchQuery().toLowerCase();
+    return this.lifestages().filter(l =>
+      !q ||
+      l.categoria_origen?.toLowerCase().includes(q) ||
+      l.categoria_destino?.toLowerCase().includes(q) ||
+      l.especie?.toLowerCase().includes(q)
+    );
+  });
+
+  isModalOpen = signal<boolean>(false);
+  isLoadingDetail = signal<boolean>(false);
+  isReadOnlyMode = signal<boolean>(false);
+  selectedLifestage = signal<LifestageCatalog | null>(null);
+  currentLifestageData = signal<Partial<LifestageCatalog>>({});
+
+  constructor() {
+    this.adminService.loadLifestages();
+  }
+
+  openModal(lifestage: LifestageCatalog | null = null) {
+    this.isReadOnlyMode.set(false);
+    if (lifestage) {
+      this.selectedLifestage.set(lifestage);
+      this.currentLifestageData.set({ ...lifestage });
+    } else {
+      this.selectedLifestage.set(null);
+      this.currentLifestageData.set(this.getEmptyLifestage());
+    }
+    this.isModalOpen.set(true);
+  }
+
+  closeModal() {
+    this.isModalOpen.set(false);
+    this.selectedLifestage.set(null);
+  }
+
+  async saveLifestage() {
+    const data = this.currentLifestageData();
+    const operation: 'insert' | 'update' = this.selectedLifestage() ? 'update' : 'insert';
+
+    if (!data.especie || !data.categoria_origen || !data.categoria_destino || !data.edad_min_meses) {
+      alert('⚠️ Especie, Categoría Origen, Categoría Destino y Edad Mínima son obligatorios.');
+      return;
+    }
+
+    if (data.categoria_origen === data.categoria_destino) {
+      alert('⚠️ La Categoría Origen y Destino no pueden ser la misma.');
+      return;
+    }
+
+    try {
+      await lastValueFrom(
+        this.adminService.saveLifestage(data, operation, this.selectedLifestage()?.id)
+      );
+      alert(operation === 'insert' ? '✅ Transición registrada correctamente' : '✅ Transición actualizada correctamente');
+      this.closeModal();
+      this.adminService.loadLifestages();
+    } catch (error) {
+      console.error('[Agro-ERP] Error al guardar la transición:', error);
+      alert('❌ Error al guardar el registro en la base de datos.');
+    }
+  }
+
+  async deleteLifestage(lifestage: LifestageCatalog) {
+    const label = `${lifestage.categoria_origen} → ${lifestage.categoria_destino}`;
+    if (!confirm(`⚠️ ¿Eliminar la transición "${label}" del catálogo? Esta acción no puede deshacerse.`)) return;
+
+    try {
+      await lastValueFrom(this.adminService.deleteLifestage(lifestage.id!));
+      this.adminService.loadLifestages();
+    } catch (error) {
+      console.error('[Agro-ERP] Error al eliminar la transición:', error);
+      alert('❌ No se pudo eliminar el registro.');
+    }
+  }
+
+  private getEmptyLifestage(): Partial<LifestageCatalog> {
+    return {
+      especie: 'BOVINO',
+      categoria_origen: '',
+      categoria_destino: '',
+      edad_min_meses: undefined,
+      requiere_validacion_peso: true,
+      notas: '',
+    };
+  }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-form-modal/lifestage-form-modal.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-form-modal/lifestage-form-modal.component.html
@@ -1,0 +1,96 @@
+@if (isOpen()) {
+<div class="modal-backdrop fade show"></div>
+<div class="modal modal-blur fade show d-block" tabindex="-1">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+        <div class="modal-content shadow-lg border-0">
+            <div class="modal-header bg-dark text-white">
+                <h5 class="modal-title">
+                    <i class="ti ti-arrow-right me-2"></i>
+                    @if (isReadonly()) {
+                    Detalle de la Transición
+                    } @else {
+                    {{ selectedLifestage() ? 'Actualizar Transición del Catálogo' : 'Alta de Nueva Transición' }}
+                    }
+                </h5>
+                <button type="button" class="btn-close btn-close-white" (click)="onClose.emit()"></button>
+            </div>
+            <div class="modal-body p-4">
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Especie <span class="text-danger">*</span></label>
+                        <select class="form-select shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="lifestageData().especie" (ngModelChange)="updateField('especie', $event)">
+                            <option value="BOVINO">Bovino</option>
+                            <option value="BUFALO">Búfalo</option>
+                            <option value="BORREGO">Borrego</option>
+                        </select>
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Edad Mínima (meses) <span class="text-danger">*</span></label>
+                        <input type="number" step="0.1" class="form-control shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="lifestageData().edad_min_meses"
+                            (ngModelChange)="updateField('edad_min_meses', $event)"
+                            placeholder="Orientativo, dispara la revisión">
+                    </div>
+                </div>
+
+                <hr class="my-4">
+                <h6 class="text-muted text-uppercase fw-bold mb-3">Transición de Categoría</h6>
+
+                <div class="row">
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Categoría Origen <span class="text-danger">*</span></label>
+                        <select class="form-select shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="lifestageData().categoria_origen" (ngModelChange)="updateField('categoria_origen', $event)">
+                            <option value="" disabled>Selecciona...</option>
+                            @for (cat of categorias; track cat) {
+                            <option [value]="cat">{{ cat }}</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-6 mb-3">
+                        <label class="form-label fw-bold">Categoría Destino <span class="text-danger">*</span></label>
+                        <select class="form-select shadow-sm" [disabled]="isReadonly()"
+                            [ngModel]="lifestageData().categoria_destino" (ngModelChange)="updateField('categoria_destino', $event)">
+                            <option value="" disabled>Selecciona...</option>
+                            @for (cat of categorias; track cat) {
+                            <option [value]="cat">{{ cat }}</option>
+                            }
+                        </select>
+                    </div>
+                </div>
+
+                <hr class="my-4">
+                <h6 class="text-muted text-uppercase fw-bold mb-3">Regla de Validación</h6>
+
+                <div class="mb-3 form-check form-switch">
+                    <input type="checkbox" class="form-check-input" role="switch" id="requiereValidacionPeso"
+                        [disabled]="isReadonly()"
+                        [ngModel]="lifestageData().requiere_validacion_peso"
+                        (ngModelChange)="updateField('requiere_validacion_peso', $event)">
+                    <label class="form-check-label" for="requiereValidacionPeso">
+                        Requiere validación de peso (además de la edad) para la transición real
+                    </label>
+                </div>
+
+                <div class="mb-3">
+                    <label class="form-label fw-bold">Notas</label>
+                    <textarea class="form-control shadow-sm" rows="2" [disabled]="isReadonly()"
+                        [ngModel]="lifestageData().notas" (ngModelChange)="updateField('notas', $event)"
+                        placeholder="Opcional"></textarea>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button class="btn btn-outline-secondary px-4 shadow-sm" (click)="onClose.emit()">
+                    {{ isReadonly() ? 'Cerrar' : 'Cancelar' }}
+                </button>
+                @if (!isReadonly()) {
+                <button class="btn btn-success px-4 shadow-sm" (click)="onSave.emit()">
+                    <i class="ti ti-device-floppy me-2"></i> Guardar Cambios
+                </button>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-form-modal/lifestage-form-modal.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/components/lifestage-form-modal/lifestage-form-modal.component.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { Component, input, model, output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { LifestageCatalog } from '@core/models/lifestage-catalog.model';
+
+@Component({
+  selector: 'app-lifestage-form-modal',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './lifestage-form-modal.component.html',
+})
+export class LifestageFormModalComponent {
+  isOpen = input.required<boolean>();
+  selectedLifestage = input<LifestageCatalog | null>(null);
+  isReadonly = input<boolean>(false);
+  lifestageData = model.required<Partial<LifestageCatalog>>();
+
+  onClose = output<void>();
+  onSave = output<void>();
+
+  readonly categorias = [
+    'BECERRA', 'NOVILLONA', 'VACA',
+    'BECERRO', 'NOVILLO', 'TORO',
+    'BUCERRA', 'BUFALA',
+    'BUCERRO', 'BUFALO',
+    'BORREGA', 'BORREGO',
+  ];
+
+  updateField(key: string, value: any) {
+    this.lifestageData.update(current => ({ ...current, [key]: value }));
+  }
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
@@ -7,6 +7,7 @@ import { Company } from '@core/models/company.model';
 import { User } from '@core/models/user.model';
 import { Guest } from '@core/models/guest.model';
 import { BreedCatalog } from '@core/models/breed-catalog.model';
+import { LifestageCatalog } from '@core/models/lifestage-catalog.model';
 import { TenantService } from 'core-auth';
 
 @Injectable({
@@ -28,6 +29,9 @@ export class AdminService {
 
   public breeds = signal<BreedCatalog[]>([]);
   public loadingBreeds = signal<boolean>(false);
+
+  public lifestages = signal<LifestageCatalog[]>([]);
+  public loadingLifestages = signal<boolean>(false);
 
   private getAuthHeaders() {
     const token = localStorage.getItem('authToken');
@@ -264,6 +268,73 @@ export class AdminService {
       id
     };
     return this.http.post<ApiResponse<any>>(`${this.apiUrl_crud}/cattle_breed_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  /* Lifestage Catalog (cattle_lifestage_catalog) — catálogo global de transiciones de etapa de vida */
+  public loadLifestages() {
+    this.loadingLifestages.set(true);
+
+    const payload = {
+      entity: 'cattle_lifestage_catalog',
+      table_name: 'cattle_lifestage_catalog',
+      operation: 'getall',
+      action: 'list',
+      filters: {}
+    };
+
+    this.http.post<ApiResponse<LifestageCatalog>>(`${this.apiUrl_crud}/cattle_lifestage_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    }).subscribe({
+      next: (res) => {
+        const data = Array.isArray(res.data) ? res.data : [];
+        const sortedLifestages = data.sort((a, b) => a.categoria_origen.localeCompare(b.categoria_origen));
+        this.lifestages.set(sortedLifestages);
+        this.loadingLifestages.set(false);
+      },
+      error: (err) => {
+        console.error('Error al cargar el catálogo de etapas de vida:', err);
+        this.lifestages.set([]);
+        this.loadingLifestages.set(false);
+      }
+    });
+  }
+
+  public getLifestageById(id: string) {
+    const payload = {
+      entity: 'cattle_lifestage_catalog',
+      table_name: 'cattle_lifestage_catalog',
+      operation: 'getone',
+      action: 'getone',
+      filters: { id }
+    };
+    return this.http.post<ApiResponse<LifestageCatalog>>(`${this.apiUrl_crud}/cattle_lifestage_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  public saveLifestage(lifestage: Partial<LifestageCatalog>, operation: 'insert' | 'update', id?: string) {
+    const payload = {
+      entity: 'cattle_lifestage_catalog',
+      table_name: 'cattle_lifestage_catalog',
+      operation,
+      id,
+      fields: lifestage
+    };
+    return this.http.post<ApiResponse<LifestageCatalog>>(`${this.apiUrl_crud}/cattle_lifestage_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  public deleteLifestage(id: string) {
+    const payload = {
+      entity: 'cattle_lifestage_catalog',
+      table_name: 'cattle_lifestage_catalog',
+      operation: 'delete',
+      id
+    };
+    return this.http.post<ApiResponse<any>>(`${this.apiUrl_crud}/cattle_lifestage_catalog`, payload, {
       headers: this.getAuthHeaders()
     });
   }

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
@@ -6,6 +6,7 @@ import { environment } from '@env/environment';
 import { Company } from '@core/models/company.model';
 import { User } from '@core/models/user.model';
 import { Guest } from '@core/models/guest.model';
+import { BreedCatalog } from '@core/models/breed-catalog.model';
 import { TenantService } from 'core-auth';
 
 @Injectable({
@@ -24,6 +25,9 @@ export class AdminService {
   public loadingReservations = signal<boolean>(false);
 
   public reservations = signal<any[]>([]);
+
+  public breeds = signal<BreedCatalog[]>([]);
+  public loadingBreeds = signal<boolean>(false);
 
   private getAuthHeaders() {
     const token = localStorage.getItem('authToken');
@@ -193,6 +197,73 @@ export class AdminService {
     };
 
     return this.http.post<ApiResponse<any>>(`${this.apiUrl_crud}/user_companies`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  /* Breed Catalog (cattle_breed_catalog) — catálogo global de estándares zootécnicos por raza */
+  public loadBreeds() {
+    this.loadingBreeds.set(true);
+
+    const payload = {
+      entity: 'cattle_breed_catalog',
+      table_name: 'cattle_breed_catalog',
+      operation: 'getall',
+      action: 'list',
+      filters: {}
+    };
+
+    this.http.post<ApiResponse<BreedCatalog>>(`${this.apiUrl_crud}/cattle_breed_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    }).subscribe({
+      next: (res) => {
+        const data = Array.isArray(res.data) ? res.data : [];
+        const sortedBreeds = data.sort((a, b) => a.raza_grupo.localeCompare(b.raza_grupo));
+        this.breeds.set(sortedBreeds);
+        this.loadingBreeds.set(false);
+      },
+      error: (err) => {
+        console.error('Error al cargar el catálogo de razas:', err);
+        this.breeds.set([]);
+        this.loadingBreeds.set(false);
+      }
+    });
+  }
+
+  public getBreedById(id: string) {
+    const payload = {
+      entity: 'cattle_breed_catalog',
+      table_name: 'cattle_breed_catalog',
+      operation: 'getone',
+      action: 'getone',
+      filters: { id }
+    };
+    return this.http.post<ApiResponse<BreedCatalog>>(`${this.apiUrl_crud}/cattle_breed_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  public saveBreed(breed: Partial<BreedCatalog>, operation: 'insert' | 'update', id?: string) {
+    const payload = {
+      entity: 'cattle_breed_catalog',
+      table_name: 'cattle_breed_catalog',
+      operation,
+      id,
+      fields: breed
+    };
+    return this.http.post<ApiResponse<BreedCatalog>>(`${this.apiUrl_crud}/cattle_breed_catalog`, payload, {
+      headers: this.getAuthHeaders()
+    });
+  }
+
+  public deleteBreed(id: string) {
+    const payload = {
+      entity: 'cattle_breed_catalog',
+      table_name: 'cattle_breed_catalog',
+      operation: 'delete',
+      id
+    };
+    return this.http.post<ApiResponse<any>>(`${this.apiUrl_crud}/cattle_breed_catalog`, payload, {
       headers: this.getAuthHeaders()
     });
   }

--- a/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.html
@@ -108,6 +108,24 @@
 
                 @if (tenantService.activeTenant()?.role === 'ADMIN') {
                 <li class="nav-item">
+                    <a class="nav-link" routerLink="/admin/razas" routerLinkActive="active" (click)="closeMenu()">
+                        <span class="nav-link-icon text-muted">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                                viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M7 20l10 0" />
+                                <path d="M6 6m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" />
+                                <path d="M6 9v11" />
+                                <path d="M9 12h4.5a3.5 3.5 0 0 0 0 -7h-1.5v10" />
+                            </svg>
+                        </span>
+                        <span class="nav-link-title">Catálogo de Raza</span>
+                    </a>
+                </li>
+                }
+
+                @if (tenantService.activeTenant()?.role === 'ADMIN') {
+                <li class="nav-item">
                     <a class="nav-link" routerLink="/admin/personal" routerLinkActive="active" (click)="closeMenu()">
                         <span class="nav-link-icon text-muted">
                             <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"

--- a/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/shared/layout/sidebar/sidebar.component.html
@@ -126,6 +126,24 @@
 
                 @if (tenantService.activeTenant()?.role === 'ADMIN') {
                 <li class="nav-item">
+                    <a class="nav-link" routerLink="/admin/etapas-vida" routerLinkActive="active" (click)="closeMenu()">
+                        <span class="nav-link-icon text-muted">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"
+                                viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none">
+                                <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                                <path d="M4 6l8 0" />
+                                <path d="M4 12l13 0" />
+                                <path d="M4 18l9 0" />
+                                <path d="M17 6l3 3l-3 3" />
+                            </svg>
+                        </span>
+                        <span class="nav-link-title">Etapas de Vida</span>
+                    </a>
+                </li>
+                }
+
+                @if (tenantService.activeTenant()?.role === 'ADMIN') {
+                <li class="nav-item">
                     <a class="nav-link" routerLink="/admin/personal" routerLinkActive="active" (click)="closeMenu()">
                         <span class="nav-link-icon text-muted">
                             <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24"


### PR DESCRIPTION
# PR: Catálogos de Configuración ADMIN — Fase 0 (Raza) + Fase 1 (Etapas de Vida)

**Branch:** `feature/v1.6.0/Parametrizacion`
**Commits incluidos:**
- `e327164` — feat(agro-erp/admin): add breed catalog (Fase 0) + fix NOVILLONA category gap
- *(pendiente de commitear)* — feat(agro-erp/admin): add lifestage catalog (Fase 1)

---

## 📋 Executive Summary

Este PR entrega las dos primeras fases de un roadmap de catálogos de configuración zootécnica para el módulo de ganadería (`agro-erp`), sentando las bases de datos y UI que las fases futuras (Protocolo Sanitario) van a consumir:

- **Fase 0 — Catálogo de Raza** (`cattle_breed_catalog`): estándares zootécnicos por raza (pesos objetivo adultos, % peso primer servicio, días de gestación). Incluye además el fix de un gap real detectado en producción: faltaba `NOVILLONA` en el `CHECK` de `cattle_livestock.category`.
- **Fase 1 — Catálogo de Etapas de Vida** (`cattle_lifestage_catalog`): transiciones de categoría por especie (ej. Becerra → Novillona → Vaca), con las 4 reglas BOVINO ya confirmadas por el cliente como datos semilla.

Ambas son configuración administrada exclusivamente por `ADMIN` desde la UI web. **Ninguna fase implementa todavía lógica que consuma estos catálogos** (eso es el Protocolo Sanitario, una fase futura separada) — no se toca el pipeline del Agente IA (WhatsApp/Chat/MCP), Zero-Hallucination/Anti-Jailbreak, ni `execute_metacrud_write` más allá del registro estándar en `crud_models` que ya usan todos los demás modelos.

**Nota sobre el diff:** este PR también incorpora por primera vez a git las migraciones `001`-`004` (preexistentes, ya aplicadas en producción desde hace meses) — no son parte del trabajo de estas fases, sino una corrección de una regla `*.sql` del `.gitignore` que las tenía silenciadas sin querer. Ver detalle en Deep Technical Details.

---

## ✅ Changes Checklist

### Fase 0 — Catálogo de Raza
- [x] Migración `005`: agrega `NOVILLONA` al `CHECK` de `cattle_livestock.category` (confirmado como gap real contra el clon local antes de tocar nada)
- [x] Migración `006`: DDL de `cattle_breed_catalog` (global, sin `tenant_id`) — 4 `CHECK` (especie, ambos pesos, % rango) + `UNIQUE` compuesto + índice único parcial para el caso `raza_variante IS NULL`
- [x] Migración `007`: registro en `crud_models` (`ADMIN` exclusivo en las 4 operaciones)
- [x] `AdminService` extendido (`loadBreeds`/`getBreedById`/`saveBreed`/`deleteBreed`)
- [x] `breed-catalog` + `breed-form-modal` (Standalone, Signals, OnPush)
- [x] Ruta `/admin/razas` + entrada de sidebar, ambas con `roleGuard(['ADMIN'])`
- [x] Aplicado y verificado en producción (incluye pruebas de violación de los 4 constraints)

### Fase 1 — Catálogo de Etapas de Vida
- [x] Migración `008`: DDL de `cattle_lifestage_catalog` — `CHECK` de categorías contra los 12 valores reales del enum `category`, `CHECK` de no-auto-transición, `CHECK` de edad > 0, `UNIQUE` compuesto. Incluye las 4 filas semilla BOVINO confirmadas por el cliente
- [x] Migración `009`: registro en `crud_models` (`ADMIN` exclusivo en las 4 operaciones)
- [x] `AdminService` extendido (`loadLifestages`/`getLifestageById`/`saveLifestage`/`deleteLifestage`)
- [x] `lifestage-catalog` + `lifestage-form-modal`, replicando exactamente el patrón visual de `breed-catalog`
- [x] Ruta `/admin/etapas-vida` + entrada de sidebar, ambas con `roleGuard(['ADMIN'])`
- [x] Aplicado y verificado en producción (incluye pruebas de violación de los 4 constraints/UNIQUE)

---

## 🔧 Deep Technical Details

**Gap de `NOVILLONA` (Fase 0):** confirmado que `category` (igual que `species`) **no es un ENUM nativo de Postgres** — es `VARCHAR` + `CHECK`. El fix fue `DROP CONSTRAINT` + `ADD CONSTRAINT` con el valor agregado, mismo patrón que la migración `001` ya usó para agregar `CUARENTENA` a `current_status`. Sin efecto en filas existentes (el nuevo `CHECK` es superconjunto del anterior).

**Gotcha de `UNIQUE` + `NULL` (Fase 0):** `cattle_breed_catalog.raza_variante` es nullable, y Postgres no trata `NULL = NULL` como duplicado en un `UNIQUE` estándar. Se agregó un índice único parcial (`WHERE raza_variante IS NULL`) para cubrir el caso "raza sin subdivisión" — verificado con un insert de violación intencional.

**`cattle_lifestage_catalog` referencia valores de `category` sin FK real (Fase 1):** como `category` en `cattle_livestock` es `VARCHAR` (no una tabla de catálogo aparte), `categoria_origen`/`categoria_destino` no pueden tener una FK — en su lugar llevan el mismo literal de 12 valores que usa el `CHECK` de `category`, mismo patrón que `especie` en ambas tablas. Si el enum de `category` cambia a futuro, este `CHECK` (y el de `cattle_breed_catalog.especie`) requieren actualización manual — trade-off aceptado y documentado en el propio DDL.

**Migraciones `001`-`004` recién trackeadas:** `.gitignore` tenía una regla `*.sql` (pensada para dumps/backups) que silenciaba sin querer *todo* `database/migrations/`, incluyendo el historial preexistente (salida de ganado, trazabilidad — ya aplicado en producción desde el Sprint 1). Se agregó una excepción explícita (`!hosting3m-workspace/projects/agro-erp/database/migrations/*.sql`) y se incorporaron las 9 migraciones a git de una vez. Esto **no es trabajo nuevo**, es deuda técnica de versionado que se aprovechó a corregir de paso.

**Ambas fases son catálogos GLOBALES** (sin `tenant_id`) — los estándares zootécnicos y las reglas de transición no varían por rancho. La protección de acceso vive enteramente en `crud_models` (`allowed_roles_*` = `ADMIN`), no en aislamiento por tenant.

---

## 🧪 Testing Protocol

- [x] `ng build agro-erp` — compila sin errores tras ambas fases
- [x] Migraciones aplicadas y verificadas contra el clon local **y en producción** (incluye pruebas de violación intencional de cada `CHECK`/`UNIQUE` en ambas tablas)
- [ ] Manual en navegador (una vez desplegado el frontend a producción):
  - [ ] ADMIN ve "Catálogo de Raza" y "Etapas de Vida" en el sidebar; un no-ADMIN no ve ninguno de los dos ni puede acceder a `/admin/razas` / `/admin/etapas-vida` directamente
  - [ ] Alta/edición/borrado de una raza y de una transición de etapa de vida
  - [ ] Confirmar que las 4 filas semilla de Etapas de Vida (Becerra→Novillona, Novillona→Vaca, Becerro→Novillo, Novillo→Toro) aparecen correctamente

---

## 👔 Senior Checklist (cumplimiento CLAUDE.md)

- [x] **Meta-CRUD intacto** — ningún flujo de escritura hacia n8n/PostgreSQL fue modificado; el único registro en `crud_models` es el estándar para exponer las 2 tablas nuevas
- [x] **Zero-Compute Client respetado** — ninguna de las 2 fases implementa lógica de negocio ni cálculo de métricas persistentes; son catálogos de configuración pura, sin consumidores todavía
- [x] **Human-in-the-Loop** — ambas fases se plantearon como plan completo (incluyendo la validación bloqueante de `NOVILLONA` y 3 decisiones de diseño de `CHECK` adicionales por fase) antes de tocar código o SQL, con confirmación explícita en cada punto
- [x] **Validación de Esquema contra Réplica Local** — ambas fases se validaron contra el clon local (`n8n-enterprise-db`) antes de aplicar en producción, incluyendo pruebas de violación de cada constraint nuevo
- [x] Sin cambios a `execute_metacrud_write`, `sp_procesar_salida_ganado`, ni ningún procedimiento almacenado existente
- [x] Sin cambios al pipeline del Agente IA (WhatsApp/Chat/MCP) ni a las reglas Zero-Hallucination/Anti-Jailbreak
