### PR TITLE
Feat(agro): SENASICA-SINIIGA regulatory registry (UPP/PSG) — backend …

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/CLAUDE.md
+++ b/hosting3m-workspace/projects/agro-erp/CLAUDE.md
@@ -13,7 +13,11 @@ Debes actuar siempre como mi **Technical Lead auxiliar y Senior Project Manager 
 ## 📐 Reglas Arquitectónicas de Oro (NO ROMPER)
 
 ### 1. Sistema Meta-CRUD y Mutación de Datos
-* **Prohibido el SQL manual para escrituras básicas:** Todas las inyecciones de datos desde n8n hacia PostgreSQL deben ejecutarse invocando la función `execute_metacrud_write(operacion, tabla, json_data)`.
+* **Prohibido el SQL manual para escrituras básicas:** las mutaciones van por el
+  gateway Meta-CRUD de n8n, no por consultas ad-hoc.
+* ⚠️ `execute_metacrud_write` existe pero está parcialmente en desuso: su
+  `p_record_id` es `integer` y falla con PKs UUID (verificado 2026-07-27).
+  El gateway construye su propio SQL. No asumir que esa función es la ruta real.
 * **Zero-Compute Client:** El frontend nunca calcula métricas persistentes (ej. peso actual). El trigger `update_current_weight` en la tabla `cattle_weight_logs` actualiza automáticamente el registro maestro del animal.
 
 ### 2. Estándar de Identificación (Biometría Interna)
@@ -29,3 +33,11 @@ Debes actuar siempre como mi **Technical Lead auxiliar y Senior Project Manager 
 
 ### 5. Validación de Esquema contra Réplica Local
 * Antes de proponer cambios de estructura de base de datos, valida contra el clon local de `hosting3m_db` (contenedor `n8n-enterprise-db`), restaurado automáticamente todos los días desde el VPS vía `~/scripts/backup_postgres_vps_to_local.sh`. No asumas el estado de producción sin confirmarlo ahí.
+
+## Contrato Meta-CRUD (verificado en producción)
+- Payload: { entity, table_name, operation (minúsculas), filters|fields, id }
+- Errores de Postgres llegan como HTTP 200 con error:true — inspeccionar siempre
+- Colecciones vacías devuelven data:[{}], no [] — filtrar por identificador
+- Toda vista registrada debe exponer created_at
+- Numéricos llegan como string: parsear explícitamente
+- Build: npx ng build agro-erp --configuration=production

--- a/hosting3m-workspace/projects/agro-erp/src/app/core/utils/gateway-empty-row.util.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/core/utils/gateway-empty-row.util.ts
@@ -1,0 +1,25 @@
+/**
+ * WORKAROUND for a confirmed n8n Meta-CRUD gateway bug: when a table has zero rows,
+ * `getall` returns `data: [{}]` (a single phantom object) instead of `data: []`.
+ * Verified against cattle_breed_catalog (0 rows in DB, UI rendered "1/1" with a blank card).
+ * Affects every model, including the compliance registry views.
+ *
+ * A row only counts as real if it carries the primary key the caller expects.
+ * `Object.keys(row).length === 0` is not a sufficient check on its own: a phantom row can
+ * also come back with real keys all set to null, still missing the identifier.
+ *
+ * Remove every call site once the gateway is fixed to return a true empty array.
+ */
+function hasIdentifier<T>(row: T | null | undefined, idKey: keyof T): boolean {
+  if (row == null) return false;
+  const id = row[idKey];
+  return id !== null && id !== undefined && String(id).trim() !== '';
+}
+
+export function isPhantomRow<T>(row: T | null | undefined, idKey: keyof T): boolean {
+  return !hasIdentifier(row, idKey);
+}
+
+export function stripPhantomRows<T>(rows: T[], idKey: keyof T): T[] {
+  return rows.filter(row => hasIdentifier(row, idKey));
+}

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/admin/services/admin.service.ts
@@ -8,6 +8,7 @@ import { User } from '@core/models/user.model';
 import { Guest } from '@core/models/guest.model';
 import { BreedCatalog } from '@core/models/breed-catalog.model';
 import { LifestageCatalog } from '@core/models/lifestage-catalog.model';
+import { stripPhantomRows } from '@core/utils/gateway-empty-row.util';
 import { TenantService } from 'core-auth';
 
 @Injectable({
@@ -221,7 +222,8 @@ export class AdminService {
       headers: this.getAuthHeaders()
     }).subscribe({
       next: (res) => {
-        const data = Array.isArray(res.data) ? res.data : [];
+        const rawData = Array.isArray(res.data) ? res.data : [];
+        const data = stripPhantomRows(rawData, 'id');
         const sortedBreeds = data.sort((a, b) => a.raza_grupo.localeCompare(b.raza_grupo));
         this.breeds.set(sortedBreeds);
         this.loadingBreeds.set(false);

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-compliance-list/upp-compliance-list.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-compliance-list/upp-compliance-list.component.html
@@ -12,11 +12,7 @@
   <div class="card-body p-0">
     @if (complianceService.loadingUpp()) {
     <div class="text-center text-muted py-5">Cargando estado de cumplimiento…</div>
-    } @else if (complianceService.uppList().length === 0) {
-    @if (!complianceService.error()) {
-    <div class="text-center text-muted py-5">No hay unidades de producción registradas.</div>
-    }
-    } @else {
+    } @else if (!complianceService.error()) {
     <div class="table-responsive">
       <table class="table card-table table-vcenter text-nowrap datatable table-hover mb-0">
         <thead>
@@ -54,6 +50,10 @@
               </span>
             </td>
             <td class="text-end font-weight-bold">{{ upp.active_head_in_system | number:'1.0-0' }}</td>
+          </tr>
+          } @empty {
+          <tr>
+            <td colspan="6" class="text-center py-5 text-muted">Sin unidades registradas.</td>
           </tr>
           }
         </tbody>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-detail/upp-detail.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-detail/upp-detail.component.html
@@ -92,7 +92,7 @@
           <dd class="col-7">{{ census.source }}</dd>
         </dl>
         } @else {
-        <div class="text-muted">No hay censo declarado registrado para esta unidad.</div>
+        <div class="text-muted">Sin censos declarados para esta unidad.</div>
         }
       </div>
     </div>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/services/compliance.service.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/services/compliance.service.ts
@@ -9,6 +9,7 @@ import {
   LivestockCensusSnapshot
 } from '../models/agro-registry.model';
 import { UppComplianceStatusView, ProductionUnitView } from '../models/compliance-view.model';
+import { isPhantomRow, stripPhantomRows } from '@core/utils/gateway-empty-row.util';
 
 const STATUS_WEIGHT: Record<string, number> = {
   EXPIRED: 0,
@@ -74,7 +75,8 @@ export class ComplianceService {
           this.error.set(res.message || 'El servidor reportó un error al consultar el estado de cumplimiento de las UPP.');
           this.uppList.set([]);
         } else {
-          const rows = Array.isArray(res.data) ? res.data : [];
+          const rawRows = Array.isArray(res.data) ? res.data : [];
+          const rows = stripPhantomRows(rawRows, 'production_unit_id');
           this.uppList.set(rows.map(row => this.mapUppRow(row)).sort(this.byCriticality));
           this.uppLoaded.set(true);
         }
@@ -108,7 +110,8 @@ export class ComplianceService {
           this.error.set(res.message || 'El servidor reportó un error al consultar la vigencia de las licencias PSG.');
           this.psgList.set([]);
         } else {
-          this.psgList.set(Array.isArray(res.data) ? res.data : []);
+          const rawRows = Array.isArray(res.data) ? res.data : [];
+          this.psgList.set(stripPhantomRows(rawRows, 'psg_license_id'));
           this.psgLoaded.set(true);
         }
         this.loadingPsg.set(false);
@@ -143,7 +146,7 @@ export class ComplianceService {
         }
 
         const raw = Array.isArray(res.data) ? res.data[0] : res.data;
-        if (!raw) {
+        if (isPhantomRow(raw, 'id')) {
           this.loadingDetail.set(false);
           return;
         }
@@ -166,7 +169,8 @@ export class ComplianceService {
         catchError(() => of<ApiResponse<LivestockCensusSnapshot>>({ error: true, operation: 'getall', message: '', data: [] }))
       )
       .subscribe(res => {
-        const rows = !res.error && Array.isArray(res.data) ? res.data : [];
+        const rawRows = !res.error && Array.isArray(res.data) ? res.data : [];
+        const rows = stripPhantomRows(rawRows, 'id');
         const latest = rows.reduce<LivestockCensusSnapshot | null>((mostRecent, row) => {
           if (!mostRecent) return row;
           return new Date(row.snapshot_date) > new Date(mostRecent.snapshot_date) ? row : mostRecent;


### PR DESCRIPTION
…+ read-only frontend (#568)

* feat(agro-erp/admin): add breed catalog (Fase 0) + fix NOVILLONA category gap

Fase 0 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de estándares zootécnicos por raza (pesos objetivo adultos, % peso primer servicio, días de gestación), administrable exclusivamente por ADMIN desde una nueva pantalla del panel de administración. No implementa aún ninguna lógica que consuma el catálogo (eso son fases futuras separadas) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local antes de aplicar en producción):
  - Migración 005: agrega NOVILLONA al CHECK de cattle_livestock.category (jerarquía Becerra → Novillona → Vaca confirmada por el cliente). category es VARCHAR + CHECK, no un ENUM nativo, así que el fix es DROP+ADD CONSTRAINT — mismo patrón que la migración 001 usó para agregar CUARENTENA a current_status.
  - Migración 006: DDL de cattle_breed_catalog (especie VARCHAR+CHECK, mismo patrón que species/category; sin FK a un catálogo de especies que no existe). Incluye índice único parcial para el caso raza_variante NULL (UNIQUE no detecta duplicados con NULL en Postgres) y CHECK de rango en pct_peso_primer_servicio.
  - Migración 007: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Aplicadas y verificadas en producción (incluye pruebas de los 4 CHECK/UNIQUE con inserts de violación intencional).

- Frontend: nuevo módulo features/admin/components/breed-catalog + breed-form-modal (Standalone, Signals, OnPush), replicando el patrón visual/interacción de tenant-list + upp-form-modal. AdminService extendido con el CRUD del catálogo. Ruta /admin/razas y entrada de sidebar protegidas por roleGuard(['ADMIN']).

- .gitignore: la regla *.sql (pensada para dumps/backups) estaba silenciando también database/migrations/ — nunca se había versionado ni el historial previo (001-004). Se agrega excepción explícita y se incorporan las 7 migraciones a git.



* feat(agro-erp/admin): add lifestage catalog (Fase 1)

Fase 1 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de transiciones de categoría por especie (ej. Becerra → Novillona → Vaca), administrable exclusivamente por ADMIN. Depende de cattle_breed_catalog (Fase 0) y del CHECK de category con NOVILLONA, ambos validados contra el clon local antes de tocar código. No implementa todavía ninguna lógica que dispare o valide transiciones reales contra cattle_livestock (Protocolo Sanitario, fase futura separada) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local, aplicado y verificado en producción):
  - Migración 008: DDL de cattle_lifestage_catalog. categoria_origen/ categoria_destino llevan CHECK contra los 12 valores reales del enum category (mismo patrón que especie en cattle_breed_catalog, evita typos), más CHECK de no-auto-transición y edad_min_meses > 0. Incluye las 4 filas semilla BOVINO confirmadas por el cliente (Búfalo/Borrego quedan pendientes de confirmación, sin filas placeholder).
  - Migración 009: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Verificadas las 4 CHECK/UNIQUE con inserts de violación intencional (categoría inválida, auto-transición, edad ≤ 0, duplicado).

- Frontend: nuevo módulo features/admin/components/lifestage-catalog + lifestage-form-modal (Standalone, Signals, OnPush), replicando exactamente el patrón visual/interacción de breed-catalog (Fase 0). AdminService extendido con el CRUD del catálogo. Ruta /admin/etapas-vida y entrada de sidebar protegidas por roleGuard(['ADMIN']).



* fix(agro): repair companys sequence before seeding new tenants

* fix(agro): expose created_at in compliance views (Meta-CRUD contract)

* fix(agro): grant tenant access for UPP companies created in migration 019

* docs(agro): add compliance frontend brief and domain models

* feat(agro): add compliance module frontend (UPP/PSG, read-only) El registro normativo SENASICA-SINIIGA está en producción (migraciones 010-022) pero sin superficie visible en el frontend: 2 de las 3 UPP del cliente llevan más de un año sin reactualizarse (662 y 537 días) y hoy no hay forma de detectarlo desde la UI. Este módulo consume los 4 modelos de solo lectura ya expuestos vía Meta-CRUD; no toca base de datos ni crud_models, ni implementa alta/edición/carga de documentos.

- Servicio (features/compliance/services/compliance.service.ts): replica el patrón "MetaCRUD Silent Error Shield" ya vigente en cattle-api.service.ts (inspecciona response.error en HTTP 200, no solo el status). Parsea explícitamente los numéricos que la API entrega como string (total_surface_ha, grazing_surface_ha, active_head_in_system) y expone un flag hasGrazingSurface derivado en el mapeo, ya que la API responde "0.00" tanto para superficie de pastoreo no declarada como para un cero real — un consumidor futuro ya no depende de recordarlo. loadUppStatus/loadPsgStatus son idempotentes (guardados por signal interno) para que la alert card del dashboard y el listado no dupliquen la petición.

- Componentes: ComplianceAlertCardComponent (embebida en main-dashboard, visible sin scroll — es el mensaje más importante de la pantalla), UppComplianceListComponent (semáforo por
  update_status, orden por criticidad: EXPIRED > WARNING > UNKNOWN >
  OK, badge de inconsistencia de superficie) y UppDetailComponent (identificación, superficie, último censo declarado, ubicación).

- Rutas lazy bajo /cumplimiento (app.routes.ts), protegidas por el authGuard ya aplicado al layout principal. Entrada de sidebar reutilizando el computed isLivestock() existente, sin lógica de dominio nueva.

- Sin localStorage/sessionStorage, sin cálculos derivados que debieran venir del servidor. ng build agro-erp --configuration=production compila sin errores ni warnings nuevos.



* fix(agro): guard against phantom rows and localize compliance status labels

The Meta-CRUD gateway returns `data: [{}]` instead of `[]` for empty collections, so every list rendered a phantom entry and reported a count of 1. Verified against cattle_breed_catalog (0 rows in the database, "1/1 razas" in the UI with a blank card).

- Add core/utils/gateway-empty-row.util.ts with stripPhantomRows/isPhantomRow, keyed on the expected primary key rather than Object.keys().length, so an object with null fields but no identifier is also discarded
- Apply the filter in ComplianceService (production_unit_id, psg_license_id, id) and in AdminService (loadBreeds, loadUsers, loadGuests, loadCompanies, loadLifestages) — loadCompanies feeds the Context Switcher
- Add empty states to the UPP list and the declared census panel
- Localize update_status and validity_status labels to Spanish in the UI; the union type values are unchanged

The util is a workaround, not a fix: the gateway itself still needs to return an empty array. Comment in the util points at the underlying bug.

---------