### PR TITLE
Registers the 4 tables introduced by migration 039 (#595)

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/database/migrations/040_crud_models_movement_tracking.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/040_crud_models_movement_tracking.sql
@@ -1,0 +1,85 @@
+-- Migration 040: Register migration 039 tables in the Meta-CRUD gateway
+--
+-- Registers psg_facilities, external_destinations, cattle_movement_events,
+-- and cattle_movement_event_animals in crud_models so the n8n gateway
+-- (06-dynamic-crud-engine) and the Angular frontend can read/write them.
+--
+-- Role pattern:
+--   - psg_facilities, external_destinations: reference catalogs, same
+--     pattern as production_units/psg_licenses (ADMIN,OWNER can write,
+--     ADMIN,EDITOR,CUSTOMER can read).
+--   - cattle_movement_events, cattle_movement_event_animals: editable per
+--     client decision, restricted to ADMIN,OWNER for INSERT/UPDATE (not
+--     EDITOR/CUSTOMER), same as production_units. No DELETE op exposed.
+--     NOTE: editing a movement event after capture has compliance
+--     implications (REEMO folio is a legal record of movement). If this
+--     becomes a real workflow need, consider replacing UPDATE with an
+--     append-only correction pattern (a new event referencing the
+--     original, same idea as historico_movimientos' REVERSION type in
+--     migration 025) instead of loosening this further.
+
+BEGIN;
+
+INSERT INTO crud_models
+    (model_name, table_name, primary_key, allowed_fields, schema_json,
+     allowed_ops, allowed_roles_select, allowed_roles_insert,
+     allowed_roles_update, allowed_roles_delete, joins, is_global)
+VALUES
+(
+    'psg_facilities',
+    'psg_facilities',
+    'id',
+    '["id", "id_company", "psg_license_id", "name", "location", "notes", "created_at"]',
+    '{"id": {"type": "text", "required": false}, "id_company": {"type": "number", "required": true}, "psg_license_id": {"type": "text", "required": false}, "name": {"type": "text", "required": true}, "location": {"type": "text", "required": false}, "notes": {"type": "text", "required": false}, "created_at": {"type": "text", "required": false}}',
+    '{SELECT,INSERT,UPDATE,GETONE,GETALL}',
+    'ADMIN,EDITOR,CUSTOMER',
+    'ADMIN,OWNER',
+    'ADMIN,OWNER',
+    'ADMIN',
+    '[{"table": "companys", "fields": {"company_name": "tenant_name"}, "own_col": "id_company", "foreign_col": "id_company"}]',
+    false
+),
+(
+    'external_destinations',
+    'external_destinations',
+    'id',
+    '["id", "id_company", "name", "contact_info", "destination_type", "notes", "created_at"]',
+    '{"id": {"type": "text", "required": false}, "id_company": {"type": "number", "required": true}, "name": {"type": "text", "required": true}, "contact_info": {"type": "text", "required": false}, "destination_type": {"type": "select", "options": ["THIRD_PARTY_RANCH", "BUYER", "SLAUGHTERHOUSE", "EXPORT", "OTHER"], "required": true}, "notes": {"type": "text", "required": false}, "created_at": {"type": "text", "required": false}}',
+    '{SELECT,INSERT,UPDATE,GETONE,GETALL}',
+    'ADMIN,EDITOR,CUSTOMER',
+    'ADMIN,OWNER',
+    'ADMIN,OWNER',
+    'ADMIN',
+    '[{"table": "companys", "fields": {"company_name": "tenant_name"}, "own_col": "id_company", "foreign_col": "id_company"}]',
+    false
+),
+(
+    'cattle_movement_events',
+    'cattle_movement_events',
+    'id',
+    '["id", "id_company", "production_unit_origin_id", "production_unit_destination_id", "psg_facility_destination_id", "external_destination_id", "rule_id", "reemo_folio", "movement_date", "captured_at", "captured_by", "status", "acknowledged_at", "acknowledged_by", "notes", "created_at"]',
+    '{"id": {"type": "text", "required": false}, "id_company": {"type": "number", "required": true}, "production_unit_origin_id": {"type": "text", "required": true}, "production_unit_destination_id": {"type": "text", "required": false}, "psg_facility_destination_id": {"type": "text", "required": false}, "external_destination_id": {"type": "text", "required": false}, "rule_id": {"type": "text", "required": false}, "reemo_folio": {"type": "text", "required": false}, "movement_date": {"type": "text", "required": true}, "captured_at": {"type": "text", "required": false}, "captured_by": {"type": "text", "required": false}, "status": {"type": "select", "options": ["COMPLETED", "PENDING_ACK", "ACKNOWLEDGED"], "required": false, "default": "COMPLETED"}, "acknowledged_at": {"type": "text", "required": false}, "acknowledged_by": {"type": "text", "required": false}, "notes": {"type": "text", "required": false}, "created_at": {"type": "text", "required": false}}',
+    '{SELECT,INSERT,UPDATE,GETONE,GETALL}',
+    'ADMIN,EDITOR,CUSTOMER',
+    'ADMIN,OWNER',
+    'ADMIN,OWNER',
+    'ADMIN',
+    '[{"table": "companys", "fields": {"company_name": "tenant_name"}, "own_col": "id_company", "foreign_col": "id_company"}]',
+    false
+),
+(
+    'cattle_movement_event_animals',
+    'cattle_movement_event_animals',
+    'id',
+    '["id", "event_id", "cattle_livestock_id", "fire_number_snapshot", "created_at"]',
+    '{"id": {"type": "text", "required": false}, "event_id": {"type": "text", "required": true}, "cattle_livestock_id": {"type": "text", "required": true}, "fire_number_snapshot": {"type": "text", "required": false}, "created_at": {"type": "text", "required": false}}',
+    '{SELECT,INSERT,UPDATE,GETONE,GETALL}',
+    'ADMIN,EDITOR,CUSTOMER',
+    'ADMIN,OWNER',
+    'ADMIN,OWNER',
+    'ADMIN',
+    '[{"table": "cattle_livestock", "fields": {"rfid_siniiga": "rfid_siniiga", "numero_fuego": "numero_fuego"}, "own_col": "cattle_livestock_id", "foreign_col": "id"}]',
+    false
+);
+
+COMMIT;


### PR DESCRIPTION
* feat(agro-erp/admin): add breed catalog (Fase 0) + fix NOVILLONA category gap

Fase 0 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de estándares zootécnicos por raza (pesos objetivo adultos, % peso primer servicio, días de gestación), administrable exclusivamente por ADMIN desde una nueva pantalla del panel de administración. No implementa aún ninguna lógica que consuma el catálogo (eso son fases futuras separadas) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local antes de aplicar en producción):
  - Migración 005: agrega NOVILLONA al CHECK de cattle_livestock.category (jerarquía Becerra → Novillona → Vaca confirmada por el cliente). category es VARCHAR + CHECK, no un ENUM nativo, así que el fix es DROP+ADD CONSTRAINT — mismo patrón que la migración 001 usó para agregar CUARENTENA a current_status.
  - Migración 006: DDL de cattle_breed_catalog (especie VARCHAR+CHECK, mismo patrón que species/category; sin FK a un catálogo de especies que no existe). Incluye índice único parcial para el caso raza_variante NULL (UNIQUE no detecta duplicados con NULL en Postgres) y CHECK de rango en pct_peso_primer_servicio.
  - Migración 007: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Aplicadas y verificadas en producción (incluye pruebas de los 4 CHECK/UNIQUE con inserts de violación intencional).

- Frontend: nuevo módulo features/admin/components/breed-catalog + breed-form-modal (Standalone, Signals, OnPush), replicando el patrón visual/interacción de tenant-list + upp-form-modal. AdminService extendido con el CRUD del catálogo. Ruta /admin/razas y entrada de sidebar protegidas por roleGuard(['ADMIN']).

- .gitignore: la regla *.sql (pensada para dumps/backups) estaba silenciando también database/migrations/ — nunca se había versionado ni el historial previo (001-004). Se agrega excepción explícita y se incorporan las 7 migraciones a git.



* feat(agro-erp/admin): add lifestage catalog (Fase 1)

Fase 1 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de transiciones de categoría por especie (ej. Becerra → Novillona → Vaca), administrable exclusivamente por ADMIN. Depende de cattle_breed_catalog (Fase 0) y del CHECK de category con NOVILLONA, ambos validados contra el clon local antes de tocar código. No implementa todavía ninguna lógica que dispare o valide transiciones reales contra cattle_livestock (Protocolo Sanitario, fase futura separada) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local, aplicado y verificado en producción):
  - Migración 008: DDL de cattle_lifestage_catalog. categoria_origen/ categoria_destino llevan CHECK contra los 12 valores reales del enum category (mismo patrón que especie en cattle_breed_catalog, evita typos), más CHECK de no-auto-transición y edad_min_meses > 0. Incluye las 4 filas semilla BOVINO confirmadas por el cliente (Búfalo/Borrego quedan pendientes de confirmación, sin filas placeholder).
  - Migración 009: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Verificadas las 4 CHECK/UNIQUE con inserts de violación intencional (categoría inválida, auto-transición, edad ≤ 0, duplicado).

- Frontend: nuevo módulo features/admin/components/lifestage-catalog + lifestage-form-modal (Standalone, Signals, OnPush), replicando exactamente el patrón visual/interacción de breed-catalog (Fase 0). AdminService extendido con el CRUD del catálogo. Ruta /admin/etapas-vida y entrada de sidebar protegidas por roleGuard(['ADMIN']).



* fix(agro): repair companys sequence before seeding new tenants

* fix(agro): expose created_at in compliance views (Meta-CRUD contract)

* fix(agro): grant tenant access for UPP companies created in migration 019

* docs(agro): add compliance frontend brief and domain models

* feat(agro): add compliance module frontend (UPP/PSG, read-only) El registro normativo SENASICA-SINIIGA está en producción (migraciones 010-022) pero sin superficie visible en el frontend: 2 de las 3 UPP del cliente llevan más de un año sin reactualizarse (662 y 537 días) y hoy no hay forma de detectarlo desde la UI. Este módulo consume los 4 modelos de solo lectura ya expuestos vía Meta-CRUD; no toca base de datos ni crud_models, ni implementa alta/edición/carga de documentos.

- Servicio (features/compliance/services/compliance.service.ts): replica el patrón "MetaCRUD Silent Error Shield" ya vigente en cattle-api.service.ts (inspecciona response.error en HTTP 200, no solo el status). Parsea explícitamente los numéricos que la API entrega como string (total_surface_ha, grazing_surface_ha, active_head_in_system) y expone un flag hasGrazingSurface derivado en el mapeo, ya que la API responde "0.00" tanto para superficie de pastoreo no declarada como para un cero real — un consumidor futuro ya no depende de recordarlo. loadUppStatus/loadPsgStatus son idempotentes (guardados por signal interno) para que la alert card del dashboard y el listado no dupliquen la petición.

- Componentes: ComplianceAlertCardComponent (embebida en main-dashboard, visible sin scroll — es el mensaje más importante de la pantalla), UppComplianceListComponent (semáforo por
  update_status, orden por criticidad: EXPIRED > WARNING > UNKNOWN >
  OK, badge de inconsistencia de superficie) y UppDetailComponent (identificación, superficie, último censo declarado, ubicación).

- Rutas lazy bajo /cumplimiento (app.routes.ts), protegidas por el authGuard ya aplicado al layout principal. Entrada de sidebar reutilizando el computed isLivestock() existente, sin lógica de dominio nueva.

- Sin localStorage/sessionStorage, sin cálculos derivados que debieran venir del servidor. ng build agro-erp --configuration=production compila sin errores ni warnings nuevos.



* fix(agro): guard against phantom rows and localize compliance status labels

The Meta-CRUD gateway returns `data: [{}]` instead of `[]` for empty collections, so every list rendered a phantom entry and reported a count of 1. Verified against cattle_breed_catalog (0 rows in the database, "1/1 razas" in the UI with a blank card).

- Add core/utils/gateway-empty-row.util.ts with stripPhantomRows/isPhantomRow, keyed on the expected primary key rather than Object.keys().length, so an object with null fields but no identifier is also discarded
- Apply the filter in ComplianceService (production_unit_id, psg_license_id, id) and in AdminService (loadBreeds, loadUsers, loadGuests, loadCompanies, loadLifestages) — loadCompanies feeds the Context Switcher
- Add empty states to the UPP list and the declared census panel
- Localize update_status and validity_status labels to Spanish in the UI; the union type values are unchanged

The util is a workaround, not a fix: the gateway itself still needs to return an empty array. Comment in the util points at the underlying bug.

* feat(agro-erp): add database migration for herd free certificates and exit rules

- Create migration 024_herd_free_certificates_and_exit_rules.sql for livestock parametrization.
- Add schema tables and constraints to track herd health free certificates (hato libre).
- Implement parametrized business rules and validation checks for livestock exit protocols.
- Ensure foreign keys and indexing are configured for audit and compliance queries.

* feat(agro): add herd-free certificates and fix livestock exit validation

The 60-day window applies to lot tests only; a unit with a current herd-free certificate is exempt. The routine also never checked for an official SINIIGA ear tag, which NOM-001-SAG/GAN-2015 requires for any movement.

- Add herd_free_certificates scoped to the production unit, one row per disease
- Add fn_has_official_ear_tag and fn_is_herd_free
- Rewrite sp_procesar_salida_ganado to check both, still as business rejections
- Add vw_livestock_movement_readiness for per-animal eligibility
- Version the REVERSION movement type applied during the 2026-07-28 incident

* fix(agro): correct UPP 54 registry data and restore truncated SINIIGA tags

* feat(agro): add brand registry, ownership and maternal lineage

* feat(agro): add equine species support; document data completeness inventory

* feat(agro): add paddocks and birth events with maternal lineage tracking

* fix(db-metadata): align crud_models with composite pk and remove phantom properties

- Update primary_key configuration to 'email, id_company' for user_companies table.
- Remove orphan 'id' key specification from users table schema_json metadata.
- Ensure strict alignment with PostgreSQL schema DDL constraints.

* docs(audit): add inventory completeness and system readiness report

- Document critical operational blockers (RFID bolo count, herd free certs, brand assignment).
- Highlight inventory discrepancies between system database and physical records (UPP 54).
- Detail domain model gaps (paddocks, calving events, ear tag lifecycle) and tech debt (DT-06, DT-09).
- Define action plan and verification SQL scripts for field audit alignment.

* docs(agro): sync CLAUDE.md, ARCHITECTURE.md and DATABASE_SCHEMA.md with v1.9.0

Documentation had not been updated since the regulatory registry work began (migrations 010-030). Three corrections matter most:

- electronic_rfid was documented as the "Primary Operational Key" with full confidence; production shows 97% of the herd (262/270) has no bolo ruminal. sp_procesar_salida_ganado keys on it, so only 8 animals can go through the official exit flow today. Flagged as a pending business decision, not fixed in code.
- Documents for the first time the Meta-CRUD gateway's three implicit runtime contracts (created_at required on every registered view, exact payload shape, empty collections returned as data:[{}] instead of []) — none were written anywhere and each cost a debugging round to discover.
- Retracts an earlier false diagnosis: a "critical allowed_fields bug" on cattle_livestock reported during design turned out not to exist in production; it came from a stale crud_models_seed.sql in the repo. Left in the record as a corrected entry rather than silently removed, since it's the operational lesson of the whole exercise.

Also documents the full Regulatory Registry Subsystem (production_units, psg_licenses, livestock_producers, brand_registrations, birth_events, production_unit_paddocks, herd_free_certificates, compliance_* tables), the corrected sp_procesar_salida_ganado rules (official tag + herd-free exemption), and the 11 new Meta-CRUD models.

* feat(agro): add leased land sites and ranch management protocols

* feat(agro): load Rancho El Triunfo adult cattle and palpation results

- 6 vacas y 17 crias nuevas + upsert de 1 semental y 12 vacas ya existentes en UPP 54
- Arete 0721391943 excluido: conflicto con NOVILLO ya existente, pendiente confirmar con cliente
- Script corregido: JSON literal roto, current_weight_kg NOT NULL, guard contra reubicar animales con production_unit_id ya asignado, exclusion real de filas con error de validacion

* feat(agro): load Ganado Rojo (201) and Pedro Tabasco batch (24)

- 201 cabezas Droughtmaster en La Bendición, 148 sin arete cargadas por quemado usando placeholder S/N-<fuego>-<fila>, mismo patron ya establecido en produccion
- Migracion 037: psg_licenses no tenia columna notes ni permitia issued_at NULL, pese a que fn_psg_validity_status ya estaba disenada para ese caso
- 24 animales de Pedro en Puyacatengo, 12 de ellos corrigen registros previos mal etiquetados como NOVILLO/VACIA -- hallazgo: el lote sospechoso de 21 detectado dias atras es en gran parte este mismo hato mal importado de origen
- rfid_siniiga es NOT NULL en produccion (no documentado); fix reutiliza el patron S/N- ya existente en vez de inventar uno nuevo

* feat(agro): alta of 3 breeding bulls via interstate transit guide (Tenosique->Palenque)

* feat(agro-erp): add cattle movement event tracking with tenant isolation

Adds cattle_movement_events and cattle_movement_event_animals as the event log for real livestock movements, complementing the existing cattle_movement_rules policy catalog (020, still unconfirmed).

- psg_facilities: models PSG as a physical destination, not just a license, per client confirmation
- external_destinations: catalog for third-party (non-tenant) destinations such as slaughterhouses and buyers
- Movement destination is exactly one of: internal production unit, internal PSG facility, or external destination (CHECK constraint)
- status column defaults to COMPLETED (today's single-party WhatsApp + photo + REEMO folio workflow); PENDING_ACK/ACKNOWLEDGED reserved for a future two-party acknowledgement flow without requiring another migration
- rule_id links to cattle_movement_rules(id) for future enforcement, nullable and unused until the policy matrix is confirmed
- Fail-closed tenant isolation via BEFORE INSERT/UPDATE triggers on both tables, since n8n_user is superuser and no RLS is in place. Verified locally and in production: cross-tenant movement is rejected, same-tenant movement succeeds.

Applied and verified against local clone and production VPS (cattle_movement_events table confirmed empty after trigger rejected the cross-tenant test insert).

* fix(security): remediate supply chain vulnerabilities across workspace and microservices

- Synchronize core Angular packages (@angular/core, @angular/common, @angular/compiler, etc.) to version 21.2.19 to patch XSS and Cache-Key ambiguity vectors.
- Implement strict resolution overrides in package.json for transitive dependencies including ip-address (^10.2.1), fast-uri (^3.1.5), dompurify (^3.4.13), undici (^6.28.0), and @hono/node-server (^2.0.12).
- Add targeted package resolution overrides for ip-address in jwt-service to eliminate SSRF and trust-boundary risks introduced via express-rate-limit.
- Purge node_modules and regenerate secure lockfiles across all scopes to guarantee zero vulnerability compliance.

* feat(agro-erp): register cattle movement tables in Meta-CRUD gateway

Registers psg_facilities, external_destinations, cattle_movement_events, and cattle_movement_event_animals in crud_models (039) so the n8n dynamic-crud-engine gateway and the Angular frontend can read/write them.

- psg_facilities, external_destinations: reference-catalog role pattern, same as production_units/psg_licenses (ADMIN,OWNER write; ADMIN,EDITOR,CUSTOMER read).
- cattle_movement_events, cattle_movement_event_animals: editable per client decision, restricted to ADMIN,OWNER for INSERT/UPDATE (not EDITOR/CUSTOMER), no DELETE op exposed. Flagged as a candidate for an append-only correction pattern instead of open UPDATE if this becomes a real workflow need, since REEMO folio is a compliance record.

Applied and verified against local clone and production VPS (ids 62-65, roles and allowed_ops confirmed via SELECT in both environments).

---------