### PR TITLE
Replaces the draft movement-rules matrix (020)  (#597)

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/database/migrations/041_normative_type_external_destinations.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/041_normative_type_external_destinations.sql
@@ -1,0 +1,33 @@
+-- Migration 041: Add normative_type to external_destinations
+--
+-- Bridges the operational/commercial destination_type vocabulary (039:
+-- THIRD_PARTY_RANCH, BUYER, SLAUGHTERHOUSE, EXPORT, OTHER) with the
+-- normative/compliance vocabulary used by cattle_movement_rules (020:
+-- UPP, PSG, RASTRO, EXPORTACION).
+--
+-- Rejected alternative: a hardcoded CASE mapping in the movement-tenant
+-- trigger. That couples two independent domains (commercial destination
+-- type vs. SENASICA-facing movement classification) inside trigger logic,
+-- and cannot represent destination_type values with no fixed normative
+-- equivalent (e.g. BUYER can legally operate as a UPP, a PSG, or ship
+-- straight to RASTRO depending on the specific buyer). Delegating the
+-- classification to a column on the row lets the person registering the
+-- destination make that call explicitly, and keeps the eventual
+-- rule_id-matching logic a plain equality check instead of embedded
+-- business logic.
+--
+-- Safe to apply as NOT NULL with no backfill: external_destinations is
+-- confirmed empty in both the local clone and production (the only row
+-- that ever existed was a test insert, already cleaned up during 039
+-- verification).
+
+BEGIN;
+
+ALTER TABLE external_destinations
+    ADD COLUMN normative_type TEXT NOT NULL
+        CHECK (normative_type IN ('UPP', 'PSG', 'RASTRO', 'EXPORTACION'));
+
+COMMENT ON COLUMN external_destinations.normative_type IS
+    'Compliance-facing classification matching cattle_movement_rules.destination_type (020). Set by whoever registers the destination — e.g. a BUYER destination_type may be classified as UPP, PSG, or RASTRO depending on how that specific buyer operates.';
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/042_movement_rules_real_business_rules.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/042_movement_rules_real_business_rules.sql
@@ -1,0 +1,136 @@
+-- Migration 042: Restructure cattle_movement_rules with real business rules
+--
+-- Confirmed by Alejandro/Pedro (audio transcript, Aug 2026), replacing the
+-- draft matrix seeded in migration 020. Key corrections vs. the draft:
+--
+--   - PSG -> UPP is NEVER allowed, in any circumstance. Once an animal
+--     enters a PSG, it can only move to another PSG (own or third-party).
+--     The draft had this as allowed by default — wrong.
+--   - What's required depends on whether the movement is INTERSTATE, not
+--     on the origin/destination pair alone. A same-state UPP->UPP or
+--     UPP->PSG movement needs only a transit guide (no health tests, no
+--     OIRSA screwworm certificate, no introduction permit). The same pair,
+--     interstate, needs all of: valid TB/BR status (or herd-free), OIRSA
+--     certificate, and the destination state's introduction permit.
+--     This is why is_interstate is now a row dimension (origin_type,
+--     destination_type, is_interstate), not a boolean attribute — the
+--     matrix goes from 8 rows to 16.
+--   - Real example of the interstate case: Tenosique (Tabasco) -> Palenque
+--     (Chiapas), already loaded in migration 038.
+--
+-- requires_destination_ack is intentionally NOT flipped to true anywhere
+-- in this migration, and is_confirmed stays false for every row except
+-- PSG->UPP (see below). The ack question was sent to Alejandro/Pedro
+-- separately and has not been answered yet. Storing the now-known values
+-- while withholding is_confirmed keeps the fail-closed guarantee intact:
+-- no enforcement activates until every relevant field for a row is
+-- actually confirmed, per the original design intent documented on this
+-- table (see migration 020's COMMENT ON COLUMN is_confirmed).
+--
+-- PSG->UPP is the one exception: it's marked is_confirmed = true
+-- immediately, because the movement is disallowed outright — there is
+-- nothing left to acknowledge on a movement that can never happen.
+--
+-- OIRSA (Organismo Internacional Regional de Sanidad Agropecuaria) issues
+-- the screwworm-free certificate required for any interstate movement.
+-- The introduction permit is issued separately by the destination state's
+-- government. Neither has a supporting table yet — both are conceptually
+-- close to compliance_certificates (a new certificate_type each), to be
+-- addressed in a follow-up migration once the document structure is
+-- confirmed in more detail. RASTRO and EXPORTACION requirements remain
+-- unconfirmed drafts (is_confirmed = false), split into interstate/local
+-- rows for schema consistency but not yet validated with the client.
+
+BEGIN;
+
+-- Preflight: nothing in cattle_movement_events references a rule yet,
+-- so this table is safe to fully restructure without orphaning data.
+DO $$
+DECLARE
+    v_ref_count INTEGER;
+BEGIN
+    SELECT count(*) INTO v_ref_count FROM cattle_movement_events WHERE rule_id IS NOT NULL;
+    IF v_ref_count > 0 THEN
+        RAISE EXCEPTION 'Aborting 042: % cattle_movement_events rows already reference a cattle_movement_rules row. Restructuring would orphan them.', v_ref_count;
+    END IF;
+END $$;
+
+ALTER TABLE cattle_movement_rules
+    ADD COLUMN is_interstate BOOLEAN,
+    ADD COLUMN requires_oirsa_certificate BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN requires_introduction_permit BOOLEAN NOT NULL DEFAULT false;
+
+-- Clear the 8 draft rows from 020 — safe per the preflight check above.
+DELETE FROM cattle_movement_rules;
+
+ALTER TABLE cattle_movement_rules
+    ALTER COLUMN is_interstate SET NOT NULL,
+    DROP COLUMN allows_interstate;
+
+ALTER TABLE cattle_movement_rules
+    DROP CONSTRAINT IF EXISTS uq_movement_rules_pair;
+
+ALTER TABLE cattle_movement_rules
+    ADD CONSTRAINT uq_movement_rules_pair UNIQUE (origin_type, destination_type, is_interstate);
+
+COMMENT ON COLUMN cattle_movement_rules.is_interstate IS
+    'Whether this rule applies to a same-state or cross-state movement. Requirements differ substantially: interstate movements require TB/BR status, an OIRSA screwworm certificate, and the destination state''s introduction permit, in addition to the transit guide required in all cases.';
+COMMENT ON COLUMN cattle_movement_rules.requires_oirsa_certificate IS
+    'Whether an OIRSA (Organismo Internacional Regional de Sanidad Agropecuaria) screwworm-free certificate is required before the transit guide can be issued. Confirmed applicable to interstate movements only.';
+COMMENT ON COLUMN cattle_movement_rules.requires_introduction_permit IS
+    'Whether the destination state''s government must issue an introduction permit before the animal can cross state lines. Confirmed applicable to interstate movements only.';
+
+INSERT INTO cattle_movement_rules
+    (origin_type, destination_type, is_interstate, is_allowed, requires_valid_psg,
+     requires_health_tests, requires_oirsa_certificate, requires_introduction_permit,
+     requires_destination_ack, is_confirmed, notes)
+VALUES
+    -- UPP -> UPP
+    ('UPP', 'UPP', false, true, false, false, false, false, false, false,
+     'CONFIRMED (audio, Aug 2026): same-owner, same-state movement between two UPPs only needs a simple transit guide. No health tests, no OIRSA, no introduction permit. requires_destination_ack left at proposed default (false, single-party WhatsApp capture); is_confirmed withheld pending stakeholder sign-off on that specific question.'),
+    ('UPP', 'UPP', true, true, true, true, true, true, false, false,
+     'CONFIRMED (audio, Aug 2026): interstate UPP-to-UPP requires valid TB/BR status (or herd-free), an OIRSA screwworm certificate, and the destination state''s introduction permit, in addition to the transit guide. Real example already in the system: Tenosique (Tabasco) -> Palenque (Chiapas), migration 038. is_confirmed withheld pending requires_destination_ack sign-off.'),
+
+    -- UPP -> PSG
+    ('UPP', 'PSG', false, true, false, false, false, false, false, false,
+     'CONFIRMED (audio, Aug 2026): same-state UPP-to-PSG only needs the transit guide, same as UPP-to-UPP local. is_confirmed withheld pending requires_destination_ack sign-off.'),
+    ('UPP', 'PSG', true, true, true, true, true, true, false, false,
+     'CONFIRMED (audio, Aug 2026): interstate UPP-to-PSG follows the full interstate protocol, same requirements as interstate UPP-to-UPP. is_confirmed withheld pending requires_destination_ack sign-off.'),
+
+    -- PSG -> PSG
+    ('PSG', 'PSG', false, true, false, false, false, false, false, false,
+     'CONFIRMED (audio, Aug 2026): same-state PSG-to-PSG only needs the transit guide. This is the ONLY movement a PSG-resident animal can make besides RASTRO/EXPORTACION. is_confirmed withheld pending requires_destination_ack sign-off.'),
+    ('PSG', 'PSG', true, true, true, true, true, true, false, false,
+     'CONFIRMED (audio, Aug 2026): interstate PSG-to-PSG follows the full interstate protocol. is_confirmed withheld pending requires_destination_ack sign-off.'),
+
+    -- PSG -> UPP: never allowed, fully confirmed, no ack dependency
+    ('PSG', 'UPP', false, false, false, false, false, false, false, true,
+     'CONFIRMED (audio, Aug 2026): a PSG-resident animal can NEVER move back to a UPP, under any circumstance, same-state or interstate. Fully confirmed and blocked outright -- no destination-ack dependency since the movement itself is disallowed.'),
+    ('PSG', 'UPP', true, false, false, false, false, false, false, true,
+     'CONFIRMED (audio, Aug 2026): see PSG->UPP local -- rule is identical and unconditional regardless of interstate status.'),
+
+    -- UPP -> RASTRO: draft, unconfirmed, preserved from migration 020
+    ('UPP', 'RASTRO', false, true, true, true, false, false, false, false,
+     'DRAFT carried over from migration 020, NOT covered by the Aug 2026 audio. Definitive exit to slaughter; no destination acknowledgement since the animal leaves the traceability chain. Currently handled by sp_procesar_salida_ganado as VENTA. Needs explicit client confirmation, especially on whether OIRSA/introduction-permit requirements apply here too when interstate.'),
+    ('UPP', 'RASTRO', true, true, true, true, false, false, false, false,
+     'DRAFT, unconfirmed -- see UPP->RASTRO local. Whether OIRSA/introduction-permit apply to an interstate RASTRO shipment is not yet confirmed.'),
+
+    -- PSG -> RASTRO: draft, unconfirmed
+    ('PSG', 'RASTRO', false, true, true, true, false, false, false, false,
+     'DRAFT carried over from migration 020, NOT covered by the Aug 2026 audio. Consistent with PSG''s stated purpose as a direct exit point to slaughter or export.'),
+    ('PSG', 'RASTRO', true, true, true, true, false, false, false, false,
+     'DRAFT, unconfirmed -- see PSG->RASTRO local.'),
+
+    -- UPP -> EXPORTACION: draft, unconfirmed
+    ('UPP', 'EXPORTACION', false, true, true, true, false, false, false, false,
+     'DRAFT carried over from migration 020, NOT covered by the Aug 2026 audio. Almost certainly needs additional federal documentation not modelled here yet.'),
+    ('UPP', 'EXPORTACION', true, true, true, true, false, false, false, false,
+     'DRAFT, unconfirmed -- see UPP->EXPORTACION local.'),
+
+    -- PSG -> EXPORTACION: draft, unconfirmed
+    ('PSG', 'EXPORTACION', false, true, true, true, false, false, false, false,
+     'DRAFT carried over from migration 020, NOT covered by the Aug 2026 audio. Consistent with PSG''s stated purpose as a direct exit point to slaughter or export.'),
+    ('PSG', 'EXPORTACION', true, true, true, true, false, false, false, false,
+     'DRAFT, unconfirmed -- see PSG->EXPORTACION local.');
+
+COMMIT;

--- a/hosting3m-workspace/projects/agro-erp/database/migrations/043_psg_origin_cattle_movement_events.sql
+++ b/hosting3m-workspace/projects/agro-erp/database/migrations/043_psg_origin_cattle_movement_events.sql
@@ -1,0 +1,133 @@
+-- Migration 043: Support PSG as a movement origin, not just a destination
+--
+-- Reverses a scope decision made during migration 039's design. At the
+-- time, the client had not yet confirmed whether livestock ever moves OUT
+-- of a PSG, so cattle_movement_events was built with origin restricted to
+-- production_units only (YAGNI). The Aug 2026 audio transcript confirms
+-- this DOES happen in practice: producers who own both UPPs and a PSG
+-- move animals from their UPP into their own PSG first, and once an
+-- animal is inside a PSG it can only move to another PSG (own or
+-- third-party) or exit to RASTRO/EXPORTACION — never back to a UPP
+-- (enforced by migration 042's PSG->UPP is_allowed=false rows).
+--
+-- This makes PSG a required possible origin, symmetric with how it's
+-- already handled as a destination in migration 039.
+
+BEGIN;
+
+-- Preflight: confirm the table is still empty before loosening a NOT NULL
+-- constraint and restructuring its exclusivity check.
+DO $$
+DECLARE
+    v_row_count INTEGER;
+BEGIN
+    SELECT count(*) INTO v_row_count FROM cattle_movement_events;
+    IF v_row_count > 0 THEN
+        RAISE EXCEPTION 'Aborting 043: cattle_movement_events has % row(s). This migration assumes an empty table; review before proceeding.', v_row_count;
+    END IF;
+END $$;
+
+ALTER TABLE cattle_movement_events
+    ALTER COLUMN production_unit_origin_id DROP NOT NULL;
+
+ALTER TABLE cattle_movement_events
+    ADD COLUMN psg_facility_origin_id UUID REFERENCES psg_facilities(id);
+
+ALTER TABLE cattle_movement_events
+    ADD CONSTRAINT chk_origin_exclusive CHECK (
+        (production_unit_origin_id IS NOT NULL AND psg_facility_origin_id IS NULL)
+        OR
+        (production_unit_origin_id IS NULL AND psg_facility_origin_id IS NOT NULL)
+    );
+
+CREATE INDEX idx_movement_events_psg_origin ON cattle_movement_events(psg_facility_origin_id);
+
+COMMENT ON COLUMN cattle_movement_events.production_unit_origin_id IS
+    'Origin production unit, if the movement originates from a UPP. Exactly one of production_unit_origin_id / psg_facility_origin_id must be set (chk_origin_exclusive).';
+COMMENT ON COLUMN cattle_movement_events.psg_facility_origin_id IS
+    'Origin PSG facility, if the movement originates from a PSG (e.g. PSG-to-PSG transfer, or PSG-to-RASTRO/EXPORTACION exit). Per migration 042, a PSG-origin movement can never target a UPP destination — enforced at the cattle_movement_rules level, not by a database constraint here.';
+
+-- Replace the tenant-isolation trigger to validate whichever origin type
+-- is actually set (mirrors the three-way destination logic already in
+-- place from migration 039).
+CREATE OR REPLACE FUNCTION trg_validate_movement_event_tenant()
+RETURNS TRIGGER AS $$
+DECLARE
+    v_origin_company INTEGER;
+    v_destination_company INTEGER;
+BEGIN
+    IF NEW.production_unit_origin_id IS NOT NULL THEN
+        SELECT id_company INTO v_origin_company
+        FROM production_units WHERE id = NEW.production_unit_origin_id;
+
+        IF v_origin_company IS NULL THEN
+            RAISE EXCEPTION 'cattle_movement_events: origin production_unit % not found', NEW.production_unit_origin_id;
+        END IF;
+
+        IF v_origin_company <> NEW.id_company THEN
+            RAISE EXCEPTION 'cattle_movement_events: origin production_unit belongs to a different tenant (event id_company=%, origin id_company=%)',
+                NEW.id_company, v_origin_company;
+        END IF;
+    END IF;
+
+    IF NEW.psg_facility_origin_id IS NOT NULL THEN
+        SELECT id_company INTO v_origin_company
+        FROM psg_facilities WHERE id = NEW.psg_facility_origin_id;
+
+        IF v_origin_company IS NULL THEN
+            RAISE EXCEPTION 'cattle_movement_events: origin psg_facility % not found', NEW.psg_facility_origin_id;
+        END IF;
+
+        IF v_origin_company <> NEW.id_company THEN
+            RAISE EXCEPTION 'cattle_movement_events: origin psg_facility belongs to a different tenant (event id_company=%, origin id_company=%)',
+                NEW.id_company, v_origin_company;
+        END IF;
+    END IF;
+
+    IF NEW.production_unit_destination_id IS NOT NULL THEN
+        SELECT id_company INTO v_destination_company
+        FROM production_units WHERE id = NEW.production_unit_destination_id;
+
+        IF v_destination_company IS NULL THEN
+            RAISE EXCEPTION 'cattle_movement_events: destination production_unit % not found', NEW.production_unit_destination_id;
+        END IF;
+
+        IF v_destination_company <> NEW.id_company THEN
+            RAISE EXCEPTION 'cattle_movement_events: cross-tenant movement is not allowed (event id_company=%, destination id_company=%). Use an ownership transfer process instead.',
+                NEW.id_company, v_destination_company;
+        END IF;
+    END IF;
+
+    IF NEW.psg_facility_destination_id IS NOT NULL THEN
+        SELECT id_company INTO v_destination_company
+        FROM psg_facilities WHERE id = NEW.psg_facility_destination_id;
+
+        IF v_destination_company IS NULL THEN
+            RAISE EXCEPTION 'cattle_movement_events: psg_facility % not found', NEW.psg_facility_destination_id;
+        END IF;
+
+        IF v_destination_company <> NEW.id_company THEN
+            RAISE EXCEPTION 'cattle_movement_events: cross-tenant movement to a PSG facility is not allowed (event id_company=%, facility id_company=%). Use an ownership transfer process instead.',
+                NEW.id_company, v_destination_company;
+        END IF;
+    END IF;
+
+    IF NEW.external_destination_id IS NOT NULL THEN
+        SELECT id_company INTO v_destination_company
+        FROM external_destinations WHERE id = NEW.external_destination_id;
+
+        IF v_destination_company IS NULL THEN
+            RAISE EXCEPTION 'cattle_movement_events: external_destination % not found', NEW.external_destination_id;
+        END IF;
+
+        IF v_destination_company <> NEW.id_company THEN
+            RAISE EXCEPTION 'cattle_movement_events: external_destination belongs to a different tenant (event id_company=%, destination id_company=%)',
+                NEW.id_company, v_destination_company;
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;


### PR DESCRIPTION
* feat(agro-erp/admin): add breed catalog (Fase 0) + fix NOVILLONA category gap

Fase 0 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de estándares zootécnicos por raza (pesos objetivo adultos, % peso primer servicio, días de gestación), administrable exclusivamente por ADMIN desde una nueva pantalla del panel de administración. No implementa aún ninguna lógica que consuma el catálogo (eso son fases futuras separadas) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local antes de aplicar en producción):
  - Migración 005: agrega NOVILLONA al CHECK de cattle_livestock.category (jerarquía Becerra → Novillona → Vaca confirmada por el cliente). category es VARCHAR + CHECK, no un ENUM nativo, así que el fix es DROP+ADD CONSTRAINT — mismo patrón que la migración 001 usó para agregar CUARENTENA a current_status.
  - Migración 006: DDL de cattle_breed_catalog (especie VARCHAR+CHECK, mismo patrón que species/category; sin FK a un catálogo de especies que no existe). Incluye índice único parcial para el caso raza_variante NULL (UNIQUE no detecta duplicados con NULL en Postgres) y CHECK de rango en pct_peso_primer_servicio.
  - Migración 007: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Aplicadas y verificadas en producción (incluye pruebas de los 4 CHECK/UNIQUE con inserts de violación intencional).

- Frontend: nuevo módulo features/admin/components/breed-catalog + breed-form-modal (Standalone, Signals, OnPush), replicando el patrón visual/interacción de tenant-list + upp-form-modal. AdminService extendido con el CRUD del catálogo. Ruta /admin/razas y entrada de sidebar protegidas por roleGuard(['ADMIN']).

- .gitignore: la regla *.sql (pensada para dumps/backups) estaba silenciando también database/migrations/ — nunca se había versionado ni el historial previo (001-004). Se agrega excepción explícita y se incorporan las 7 migraciones a git.



* feat(agro-erp/admin): add lifestage catalog (Fase 1)

Fase 1 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de transiciones de categoría por especie (ej. Becerra → Novillona → Vaca), administrable exclusivamente por ADMIN. Depende de cattle_breed_catalog (Fase 0) y del CHECK de category con NOVILLONA, ambos validados contra el clon local antes de tocar código. No implementa todavía ninguna lógica que dispare o valide transiciones reales contra cattle_livestock (Protocolo Sanitario, fase futura separada) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local, aplicado y verificado en producción):
  - Migración 008: DDL de cattle_lifestage_catalog. categoria_origen/ categoria_destino llevan CHECK contra los 12 valores reales del enum category (mismo patrón que especie en cattle_breed_catalog, evita typos), más CHECK de no-auto-transición y edad_min_meses > 0. Incluye las 4 filas semilla BOVINO confirmadas por el cliente (Búfalo/Borrego quedan pendientes de confirmación, sin filas placeholder).
  - Migración 009: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Verificadas las 4 CHECK/UNIQUE con inserts de violación intencional (categoría inválida, auto-transición, edad ≤ 0, duplicado).

- Frontend: nuevo módulo features/admin/components/lifestage-catalog + lifestage-form-modal (Standalone, Signals, OnPush), replicando exactamente el patrón visual/interacción de breed-catalog (Fase 0). AdminService extendido con el CRUD del catálogo. Ruta /admin/etapas-vida y entrada de sidebar protegidas por roleGuard(['ADMIN']).



* fix(agro): repair companys sequence before seeding new tenants

* fix(agro): expose created_at in compliance views (Meta-CRUD contract)

* fix(agro): grant tenant access for UPP companies created in migration 019

* docs(agro): add compliance frontend brief and domain models

* feat(agro): add compliance module frontend (UPP/PSG, read-only) El registro normativo SENASICA-SINIIGA está en producción (migraciones 010-022) pero sin superficie visible en el frontend: 2 de las 3 UPP del cliente llevan más de un año sin reactualizarse (662 y 537 días) y hoy no hay forma de detectarlo desde la UI. Este módulo consume los 4 modelos de solo lectura ya expuestos vía Meta-CRUD; no toca base de datos ni crud_models, ni implementa alta/edición/carga de documentos.

- Servicio (features/compliance/services/compliance.service.ts): replica el patrón "MetaCRUD Silent Error Shield" ya vigente en cattle-api.service.ts (inspecciona response.error en HTTP 200, no solo el status). Parsea explícitamente los numéricos que la API entrega como string (total_surface_ha, grazing_surface_ha, active_head_in_system) y expone un flag hasGrazingSurface derivado en el mapeo, ya que la API responde "0.00" tanto para superficie de pastoreo no declarada como para un cero real — un consumidor futuro ya no depende de recordarlo. loadUppStatus/loadPsgStatus son idempotentes (guardados por signal interno) para que la alert card del dashboard y el listado no dupliquen la petición.

- Componentes: ComplianceAlertCardComponent (embebida en main-dashboard, visible sin scroll — es el mensaje más importante de la pantalla), UppComplianceListComponent (semáforo por
  update_status, orden por criticidad: EXPIRED > WARNING > UNKNOWN >
  OK, badge de inconsistencia de superficie) y UppDetailComponent (identificación, superficie, último censo declarado, ubicación).

- Rutas lazy bajo /cumplimiento (app.routes.ts), protegidas por el authGuard ya aplicado al layout principal. Entrada de sidebar reutilizando el computed isLivestock() existente, sin lógica de dominio nueva.

- Sin localStorage/sessionStorage, sin cálculos derivados que debieran venir del servidor. ng build agro-erp --configuration=production compila sin errores ni warnings nuevos.



* fix(agro): guard against phantom rows and localize compliance status labels

The Meta-CRUD gateway returns `data: [{}]` instead of `[]` for empty collections, so every list rendered a phantom entry and reported a count of 1. Verified against cattle_breed_catalog (0 rows in the database, "1/1 razas" in the UI with a blank card).

- Add core/utils/gateway-empty-row.util.ts with stripPhantomRows/isPhantomRow, keyed on the expected primary key rather than Object.keys().length, so an object with null fields but no identifier is also discarded
- Apply the filter in ComplianceService (production_unit_id, psg_license_id, id) and in AdminService (loadBreeds, loadUsers, loadGuests, loadCompanies, loadLifestages) — loadCompanies feeds the Context Switcher
- Add empty states to the UPP list and the declared census panel
- Localize update_status and validity_status labels to Spanish in the UI; the union type values are unchanged

The util is a workaround, not a fix: the gateway itself still needs to return an empty array. Comment in the util points at the underlying bug.

* feat(agro-erp): add database migration for herd free certificates and exit rules

- Create migration 024_herd_free_certificates_and_exit_rules.sql for livestock parametrization.
- Add schema tables and constraints to track herd health free certificates (hato libre).
- Implement parametrized business rules and validation checks for livestock exit protocols.
- Ensure foreign keys and indexing are configured for audit and compliance queries.

* feat(agro): add herd-free certificates and fix livestock exit validation

The 60-day window applies to lot tests only; a unit with a current herd-free certificate is exempt. The routine also never checked for an official SINIIGA ear tag, which NOM-001-SAG/GAN-2015 requires for any movement.

- Add herd_free_certificates scoped to the production unit, one row per disease
- Add fn_has_official_ear_tag and fn_is_herd_free
- Rewrite sp_procesar_salida_ganado to check both, still as business rejections
- Add vw_livestock_movement_readiness for per-animal eligibility
- Version the REVERSION movement type applied during the 2026-07-28 incident

* fix(agro): correct UPP 54 registry data and restore truncated SINIIGA tags

* feat(agro): add brand registry, ownership and maternal lineage

* feat(agro): add equine species support; document data completeness inventory

* feat(agro): add paddocks and birth events with maternal lineage tracking

* fix(db-metadata): align crud_models with composite pk and remove phantom properties

- Update primary_key configuration to 'email, id_company' for user_companies table.
- Remove orphan 'id' key specification from users table schema_json metadata.
- Ensure strict alignment with PostgreSQL schema DDL constraints.

* docs(audit): add inventory completeness and system readiness report

- Document critical operational blockers (RFID bolo count, herd free certs, brand assignment).
- Highlight inventory discrepancies between system database and physical records (UPP 54).
- Detail domain model gaps (paddocks, calving events, ear tag lifecycle) and tech debt (DT-06, DT-09).
- Define action plan and verification SQL scripts for field audit alignment.

* docs(agro): sync CLAUDE.md, ARCHITECTURE.md and DATABASE_SCHEMA.md with v1.9.0

Documentation had not been updated since the regulatory registry work began (migrations 010-030). Three corrections matter most:

- electronic_rfid was documented as the "Primary Operational Key" with full confidence; production shows 97% of the herd (262/270) has no bolo ruminal. sp_procesar_salida_ganado keys on it, so only 8 animals can go through the official exit flow today. Flagged as a pending business decision, not fixed in code.
- Documents for the first time the Meta-CRUD gateway's three implicit runtime contracts (created_at required on every registered view, exact payload shape, empty collections returned as data:[{}] instead of []) — none were written anywhere and each cost a debugging round to discover.
- Retracts an earlier false diagnosis: a "critical allowed_fields bug" on cattle_livestock reported during design turned out not to exist in production; it came from a stale crud_models_seed.sql in the repo. Left in the record as a corrected entry rather than silently removed, since it's the operational lesson of the whole exercise.

Also documents the full Regulatory Registry Subsystem (production_units, psg_licenses, livestock_producers, brand_registrations, birth_events, production_unit_paddocks, herd_free_certificates, compliance_* tables), the corrected sp_procesar_salida_ganado rules (official tag + herd-free exemption), and the 11 new Meta-CRUD models.

* feat(agro): add leased land sites and ranch management protocols

* feat(agro): load Rancho El Triunfo adult cattle and palpation results

- 6 vacas y 17 crias nuevas + upsert de 1 semental y 12 vacas ya existentes en UPP 54
- Arete 0721391943 excluido: conflicto con NOVILLO ya existente, pendiente confirmar con cliente
- Script corregido: JSON literal roto, current_weight_kg NOT NULL, guard contra reubicar animales con production_unit_id ya asignado, exclusion real de filas con error de validacion

* feat(agro): load Ganado Rojo (201) and Pedro Tabasco batch (24)

- 201 cabezas Droughtmaster en La Bendición, 148 sin arete cargadas por quemado usando placeholder S/N-<fuego>-<fila>, mismo patron ya establecido en produccion
- Migracion 037: psg_licenses no tenia columna notes ni permitia issued_at NULL, pese a que fn_psg_validity_status ya estaba disenada para ese caso
- 24 animales de Pedro en Puyacatengo, 12 de ellos corrigen registros previos mal etiquetados como NOVILLO/VACIA -- hallazgo: el lote sospechoso de 21 detectado dias atras es en gran parte este mismo hato mal importado de origen
- rfid_siniiga es NOT NULL en produccion (no documentado); fix reutiliza el patron S/N- ya existente en vez de inventar uno nuevo

* feat(agro): alta of 3 breeding bulls via interstate transit guide (Tenosique->Palenque)

* feat(agro-erp): add cattle movement event tracking with tenant isolation

Adds cattle_movement_events and cattle_movement_event_animals as the event log for real livestock movements, complementing the existing cattle_movement_rules policy catalog (020, still unconfirmed).

- psg_facilities: models PSG as a physical destination, not just a license, per client confirmation
- external_destinations: catalog for third-party (non-tenant) destinations such as slaughterhouses and buyers
- Movement destination is exactly one of: internal production unit, internal PSG facility, or external destination (CHECK constraint)
- status column defaults to COMPLETED (today's single-party WhatsApp + photo + REEMO folio workflow); PENDING_ACK/ACKNOWLEDGED reserved for a future two-party acknowledgement flow without requiring another migration
- rule_id links to cattle_movement_rules(id) for future enforcement, nullable and unused until the policy matrix is confirmed
- Fail-closed tenant isolation via BEFORE INSERT/UPDATE triggers on both tables, since n8n_user is superuser and no RLS is in place. Verified locally and in production: cross-tenant movement is rejected, same-tenant movement succeeds.

Applied and verified against local clone and production VPS (cattle_movement_events table confirmed empty after trigger rejected the cross-tenant test insert).

* fix(security): remediate supply chain vulnerabilities across workspace and microservices

- Synchronize core Angular packages (@angular/core, @angular/common, @angular/compiler, etc.) to version 21.2.19 to patch XSS and Cache-Key ambiguity vectors.
- Implement strict resolution overrides in package.json for transitive dependencies including ip-address (^10.2.1), fast-uri (^3.1.5), dompurify (^3.4.13), undici (^6.28.0), and @hono/node-server (^2.0.12).
- Add targeted package resolution overrides for ip-address in jwt-service to eliminate SSRF and trust-boundary risks introduced via express-rate-limit.
- Purge node_modules and regenerate secure lockfiles across all scopes to guarantee zero vulnerability compliance.

* feat(agro-erp): register cattle movement tables in Meta-CRUD gateway

Registers psg_facilities, external_destinations, cattle_movement_events, and cattle_movement_event_animals in crud_models (039) so the n8n dynamic-crud-engine gateway and the Angular frontend can read/write them.

- psg_facilities, external_destinations: reference-catalog role pattern, same as production_units/psg_licenses (ADMIN,OWNER write; ADMIN,EDITOR,CUSTOMER read).
- cattle_movement_events, cattle_movement_event_animals: editable per client decision, restricted to ADMIN,OWNER for INSERT/UPDATE (not EDITOR/CUSTOMER), no DELETE op exposed. Flagged as a candidate for an append-only correction pattern instead of open UPDATE if this becomes a real workflow need, since REEMO folio is a compliance record.

Applied and verified against local clone and production VPS (ids 62-65, roles and allowed_ops confirmed via SELECT in both environments).

* feat(agro-erp): bridge external_destinations to the movement rules vocabulary

Adds normative_type to external_destinations, a compliance-facing classification matching cattle_movement_rules.destination_type (020): UPP, PSG, RASTRO, or EXPORTACION.

Rejected a hardcoded CASE mapping from destination_type (039's commercial vocabulary: THIRD_PARTY_RANCH, BUYER, SLAUGHTERHOUSE, EXPORT, OTHER) to the normative vocabulary in trigger logic, since that couples two independent domains and cannot represent destination_type values with no fixed normative equivalent (a BUYER may legally operate as a UPP, a PSG, or ship straight to RASTRO depending on the specific buyer). Delegating classification to a column keeps the eventual rule_id-matching logic a plain equality check.

Applied as NOT NULL with no backfill: external_destinations was confirmed empty in both environments before this migration.

Applied and verified against local clone and production VPS.

* feat(agro-erp): replace draft movement rules with confirmed business rules

Migration 042 replaces the 8 draft rows in cattle_movement_rules (020) with 16 rows reflecting real SENASICA/REEMO business rules confirmed by Alejandro/Pedro (audio transcript, Aug 2026):

- PSG -> UPP is now permanently disallowed (is_allowed=false, is_confirmed=true, both local and interstate) — a PSG-resident animal can never return to a UPP. The draft had this allowed by default, which was wrong.
- Requirements now depend on is_interstate, not just the origin/ destination pair: same-state UPP-UPP/UPP-PSG/PSG-PSG movements only need a transit guide; interstate movements additionally require TB/BR status (or herd-free), an OIRSA screwworm certificate, and the destination state's introduction permit.
- is_confirmed is withheld (false) on all rows except PSG->UPP, pending stakeholder sign-off on requires_destination_ack, which was asked separately and remains unanswered. Values are stored so nothing needs to be re-asked once that answer arrives.
- RASTRO/EXPORTACION rows remain unconfirmed drafts, split into interstate/local for schema consistency but not covered by the audio.

Migration 043 reverses a scope decision from 039: adds psg_facility_origin_id to cattle_movement_events (production_unit_origin_id is now nullable), since the same audio confirmed PSG-to-PSG and PSG-to-RASTRO/EXPORTACION movements originate from a PSG in practice. Mirrors the existing three-way destination exclusivity pattern (chk_origin_exclusive) and extends the tenant-isolation trigger accordingly.

Both migrations include a preflight guard (DO block) that aborts if cattle_movement_events already has data referencing what's being restructured — verified empty (0 rows) in both environments before applying.

Applied and verified against local clone and production VPS. Backup taken before production apply (pre_migracion_042_043_20260811_093113.dump).

---------