### PR TITLE
Fix(agro-erp): normalize page-title font-size and fix text-dark contr…

### DIFF
--- a/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-compliance-list/upp-compliance-list.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-compliance-list/upp-compliance-list.component.html
@@ -1,6 +1,6 @@
 <div class="page-header d-print-none mb-4">
   <div class="page-pretitle text-uppercase font-weight-bold text-muted">Cumplimiento Normativo</div>
-  <h2 class="page-title font-weight-bold" style="font-size: 1.5rem;">Padrón Ganadero — Unidades de Producción (UPP)
+  <h2 class="page-title font-weight-bold">Padrón Ganadero — Unidades de Producción (UPP)
   </h2>
 </div>
 

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-detail/upp-detail.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/compliance/components/upp-detail/upp-detail.component.html
@@ -2,7 +2,7 @@
   <div class="page-pretitle text-uppercase font-weight-bold text-muted">
     <a routerLink="/cumplimiento/upp" class="text-muted text-decoration-none">← Cumplimiento Normativo</a>
   </div>
-  <h2 class="page-title font-weight-bold" style="font-size: 1.5rem;">
+  <h2 class="page-title font-weight-bold">
     {{ complianceService.uppDetail()?.ranch_name || 'Detalle de Unidad de Producción' }}
   </h2>
 </div>

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.html
@@ -2,7 +2,7 @@
     <div class="row g-2 align-items-center">
         <div class="col-12 col-md">
             <div class="page-pretitle text-uppercase font-weight-bold text-muted">Resumen Ejecutivo</div>
-            <h2 class="page-title font-weight-bold" style="font-size: 1.5rem;">Capitalización y Rendimiento</h2>
+            <h2 class="page-title font-weight-bold">Capitalización y Rendimiento</h2>
         </div>
 
         <div class="col-12 col-md-auto ms-md-auto d-print-none mt-2 mt-md-0">

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/main-dashboard/main-dashboard.component.ts
@@ -35,7 +35,6 @@ export class MainDashboardComponent implements OnInit {
   public isLoading = signal<boolean>(true);
 
   // Navegación y Filtros de Trazabilidad Biológica
-  public activeTab = signal<'CRIA' | 'ENGORDA'>('CRIA');
   public activeSubTab = signal<'RESUMEN' | 'INVENTARIO' | 'GASTOS' | 'POR_ANIMAL'>('RESUMEN');
   public selectedSpecies = signal<string>('TODOS'); // 🚀 Filtro maestro de especie
   public showExpenseModal = signal<boolean>(false);
@@ -46,8 +45,15 @@ export class MainDashboardComponent implements OnInit {
   // Controlador de Paginación Reutilizable (ver mejora #3: composable basado en signals)
   public pagination = new Paginator(() => this.currentDataset().length);
 
-  // Bridge reactivo: convierte los queryParams del Router en un Signal nativo de Angular
-  private queryParams = toSignal(this.route.queryParamMap);
+  // Bridge reactivo: convierte los queryParams del Router en un Signal nativo de Angular.
+  // initialValue evita `undefined` en el primer render (antes de que ActivatedRoute emita).
+  private queryParams = toSignal(this.route.queryParamMap, { initialValue: this.route.snapshot.queryParamMap });
+
+  // 🔗 Fuente única de verdad: el módulo activo se deriva de la URL (?tab=), nunca se escribe
+  // directamente. setTab() solo navega; este computed reacciona al cambio de queryParams.
+  public activeTab = computed<'CRIA' | 'ENGORDA'>(() =>
+    this.queryParams().get('tab')?.toUpperCase() === 'ENGORDA' ? 'ENGORDA' : 'CRIA'
+  );
 
   constructor() {
     /**
@@ -63,6 +69,14 @@ export class MainDashboardComponent implements OnInit {
         this.loadDashboardData();
       }
     }, { allowSignalWrites: true }); // Permite que la escritura de isLoading y listas ocurra en cascada
+
+    // 🔄 EFECTO REACTIVO: al cambiar de módulo (CRIA/ENGORDA) resetea la sub-pestaña activa
+    // y la paginación, para no dejar al usuario en una página de tabla vacía tras el cambio.
+    effect(() => {
+      this.activeTab();
+      this.activeSubTab.set('RESUMEN');
+      this.pagination.reset();
+    }, { allowSignalWrites: true });
   }
 
   ngOnInit() {
@@ -193,8 +207,8 @@ export class MainDashboardComponent implements OnInit {
   });
 
   public setTab(tab: 'CRIA' | 'ENGORDA') {
-    // Navega actualizando solo el query param 'tab'. El EFECTO 1 en el constructor
-    // escucha el cambio y propaga la actualización a activeTab, activeSubTab y currentPage.
+    // Solo navega — activeTab es un computed derivado de la URL, se recalcula solo.
+    // El effect del constructor reacciona a ese cambio y resetea subTab/paginación.
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { tab: tab.toLowerCase() },

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.html
@@ -61,7 +61,18 @@
 
     @if (!isTableCollapsed()) {
     <div class="card-body border-bottom py-3">
-        <div class="d-flex align-items-center">
+        <div class="row g-2 mb-3">
+            <div class="col-auto">
+                <span class="badge bg-secondary-lt">{{ diagnosisSummary().sinDiagnostico }} Sin Diagnóstico</span>
+            </div>
+            <div class="col-auto">
+                <span class="badge bg-green-lt">{{ diagnosisSummary().prenadas }} Preñadas</span>
+            </div>
+            <div class="col-auto">
+                <span class="badge bg-danger-lt">{{ diagnosisSummary().vacias }} Vacías</span>
+            </div>
+        </div>
+        <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-2">
             <div class="text-muted">
                 Mostrar
                 <div class="mx-2 d-inline-block">
@@ -73,6 +84,19 @@
                 </div>
                 registros clínicos
             </div>
+            <div class="input-icon" style="max-width: 320px;">
+                <span class="input-icon-addon">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="icon" width="24" height="24" viewBox="0 0 24 24"
+                        stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round"
+                        stroke-linejoin="round">
+                        <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+                        <path d="M10 10m-7 0a7 7 0 1 0 14 0a7 7 0 1 0 -14 0" />
+                        <path d="M21 21l-6 -6" />
+                    </svg>
+                </span>
+                <input type="text" class="form-control form-control-sm" placeholder="Buscar por arete o número de fuego..."
+                    [value]="searchQuery()" (input)="setSearch($any($event.target).value)">
+            </div>
         </div>
     </div>
 
@@ -80,10 +104,30 @@
         <table class="table table-vcenter table-hover mb-0">
             <thead>
                 <tr>
-                    <th>Arete (SINIIGA)</th>
-                    <th>Estado</th>
-                    <th>Días Gestación</th>
-                    <th>Condición Uterina</th>
+                    <th style="cursor: pointer;" (click)="setSort('rfid_siniiga')">
+                        Arete (SINIIGA)
+                        @if (sortColumn() === 'rfid_siniiga') {
+                        <span class="text-muted">{{ sortDirection() === 'asc' ? '▲' : '▼' }}</span>
+                        }
+                    </th>
+                    <th style="cursor: pointer;" (click)="setSort('last_palpation_result')">
+                        Estado
+                        @if (sortColumn() === 'last_palpation_result') {
+                        <span class="text-muted">{{ sortDirection() === 'asc' ? '▲' : '▼' }}</span>
+                        }
+                    </th>
+                    <th style="cursor: pointer;" (click)="setSort('current_gestation_days')">
+                        Días Gestación
+                        @if (sortColumn() === 'current_gestation_days') {
+                        <span class="text-muted">{{ sortDirection() === 'asc' ? '▲' : '▼' }}</span>
+                        }
+                    </th>
+                    <th style="cursor: pointer;" (click)="setSort('condicion_utero')">
+                        Condición Uterina
+                        @if (sortColumn() === 'condicion_utero') {
+                        <span class="text-muted">{{ sortDirection() === 'asc' ? '▲' : '▼' }}</span>
+                        }
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -93,13 +137,21 @@
                         <div class="font-monospace text-primary font-weight-bold">{{ animal.rfid_siniiga }}</div>
                     </td>
                     <td>
+                        @if (!animal.last_palpation_result) {
+                        <span class="badge bg-secondary-lt">Sin Diagnóstico</span>
+                        } @else {
                         <span class="badge" [class.bg-green-lt]="animal.last_palpation_result === 'PREÑADA'"
                             [class.bg-danger-lt]="animal.last_palpation_result === 'VACIA'">
-                            {{ animal.last_palpation_result || 'N/A' }}
+                            {{ animal.last_palpation_result }}
                         </span>
+                        }
                     </td>
                     <td>{{ animal.current_gestation_days || 0 }} días</td>
                     <td class="text-muted">{{ animal.condicion_utero || 'N/A' }}</td>
+                </tr>
+                } @empty {
+                <tr>
+                    <td colspan="4" class="text-center py-5 text-muted">Sin resultados para la búsqueda actual.</td>
                 </tr>
                 }
             </tbody>
@@ -109,7 +161,7 @@
     <div class="card-footer d-flex align-items-center border-top">
         <p class="m-0 text-muted">
             Mostrando <span>{{ pagination.showingStart() }}</span> a <span>{{ pagination.showingEnd() }}</span>
-            de <span>{{ data().length }}</span> vientres bajo control
+            de <span>{{ processedData().length }}</span> vientres bajo control
         </p>
         <ul class="pagination m-0 ms-auto">
             <li class="page-item" [class.disabled]="pagination.currentPage() === 1">

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.ts
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/dashboard/components/reproductive-dashboard/reproductive-dashboard.component.ts
@@ -5,6 +5,8 @@ import { Livestock } from '../../../models/livestock.model';
 import { Paginator } from '../../utils/paginator';
 import { ThemeService } from '@core/services/theme.service';
 
+type SortColumn = 'rfid_siniiga' | 'last_palpation_result' | 'current_gestation_days' | 'condicion_utero';
+
 @Component({
   selector: 'app-reproductive-dashboard',
   standalone: true,
@@ -23,18 +25,72 @@ export class ReproductiveDashboardComponent {
   // Controladores de Estado de Interfaz
   public isTableCollapsed = signal(true);
 
+  // 🔎 Búsqueda reactiva de la auditoría (arete SINIIGA o número de fuego)
+  public searchQuery = signal<string>('');
+
+  // ↕️ Ordenamiento por columna — por defecto, gestación más avanzada primero
+  public sortColumn = signal<SortColumn>('current_gestation_days');
+  public sortDirection = signal<'asc' | 'desc'>('desc');
+
   // 🚀 Paginación Reutilizable (composable basado en signals, compartido con main-dashboard)
-  public pagination = new Paginator(() => this.data().length);
+  public pagination = new Paginator(() => this.processedData().length);
+
+  // Búsqueda + orden aplicados sobre `data()` antes de paginar
+  public processedData = computed(() => {
+    const query = this.searchQuery().trim().toLowerCase();
+    const filtered = !query
+      ? this.data()
+      : this.data().filter(animal =>
+          animal.rfid_siniiga?.toLowerCase().includes(query) ||
+          animal.numero_fuego?.toLowerCase().includes(query)
+        );
+
+    const column = this.sortColumn();
+    const direction = this.sortDirection() === 'asc' ? 1 : -1;
+
+    return [...filtered].sort((a, b) => {
+      if (column === 'current_gestation_days') {
+        return (Number(a.current_gestation_days || 0) - Number(b.current_gestation_days || 0)) * direction;
+      }
+      const valueA = (a[column] ?? '').toString();
+      const valueB = (b[column] ?? '').toString();
+      return valueA.localeCompare(valueB) * direction;
+    });
+  });
 
   // Slice de datos en memoria basado en la página seleccionada
   public paginatedData = computed(() => {
     const startIndex = (this.pagination.currentPage() - 1) * this.pagination.pageSize();
-    return this.data().slice(startIndex, startIndex + this.pagination.pageSize());
+    return this.processedData().slice(startIndex, startIndex + this.pagination.pageSize());
+  });
+
+  // 📊 Resumen numérico rápido: distingue "sin diagnóstico" de diagnosticadas PREÑADA/VACIA
+  public diagnosisSummary = computed(() => {
+    const list = this.data();
+    const sinDiagnostico = list.filter(a => !a.last_palpation_result).length;
+    const prenadas = list.filter(a => a.last_palpation_result === 'PREÑADA').length;
+    const vacias = list.filter(a => a.last_palpation_result === 'VACIA').length;
+    return { total: list.length, sinDiagnostico, prenadas, vacias };
   });
 
   public toggleTable() {
     this.isTableCollapsed.update(state => !state);
     this.pagination.reset(); // Reset de seguridad al colapsar/expandir
+  }
+
+  public setSearch(query: string) {
+    this.searchQuery.set(query);
+    this.pagination.reset();
+  }
+
+  public setSort(column: SortColumn) {
+    if (this.sortColumn() === column) {
+      this.sortDirection.update(dir => (dir === 'asc' ? 'desc' : 'asc'));
+    } else {
+      this.sortColumn.set(column);
+      this.sortDirection.set('asc');
+    }
+    this.pagination.reset();
   }
 
   // Indicadores Clínicos Derivados

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/inventory/components/cattle-list/cattle-list.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/inventory/components/cattle-list/cattle-list.component.html
@@ -4,7 +4,7 @@
             <div class="page-pretitle text-uppercase font-weight-bold text-muted">
                 Gestión de Inventario | {{ tenantService.activeTenant()?.company_name }}
             </div>
-            <h2 class="page-title text-dark font-weight-bold" style="font-size: 1.5rem;">Censo Biológico Activo</h2>
+            <h2 class="page-title font-weight-bold">Censo Biológico Activo</h2>
         </div>
         <div class="col-auto ms-auto d-print-none">
             <div class="btn-list">

--- a/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/weighing/components/adg-alerts/adg-alerts.component.html
+++ b/hosting3m-workspace/projects/agro-erp/src/app/features/livestock/weighing/components/adg-alerts/adg-alerts.component.html
@@ -2,7 +2,7 @@
     <div class="row align-items-center">
         <div class="col">
             <div class="page-pretitle text-uppercase font-weight-bold text-danger">Atención Inmediata</div>
-            <h2 class="page-title text-dark font-weight-bold" style="font-size: 1.5rem;">Mermas y Alertas Operativas
+            <h2 class="page-title font-weight-bold">Mermas y Alertas Operativas
             </h2>
         </div>
     </div>

--- a/hosting3m-workspace/projects/agro-erp/src/styles.scss
+++ b/hosting3m-workspace/projects/agro-erp/src/styles.scss
@@ -10,3 +10,8 @@ body,
     background-color: var(--tblr-card-bg, #ffffff) !important;
     color: inherit;
 }
+
+/* Tabler default thead th is 0.625rem (10px), too small against 0.875rem (14px) td content on dense tables */
+.table thead th {
+    font-size: 0.75rem !important;
+}


### PR DESCRIPTION
…ast bug in dark mode (#599)

* feat(agro-erp/admin): add breed catalog (Fase 0) + fix NOVILLONA category gap

Fase 0 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de estándares zootécnicos por raza (pesos objetivo adultos, % peso primer servicio, días de gestación), administrable exclusivamente por ADMIN desde una nueva pantalla del panel de administración. No implementa aún ninguna lógica que consuma el catálogo (eso son fases futuras separadas) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local antes de aplicar en producción):
  - Migración 005: agrega NOVILLONA al CHECK de cattle_livestock.category (jerarquía Becerra → Novillona → Vaca confirmada por el cliente). category es VARCHAR + CHECK, no un ENUM nativo, así que el fix es DROP+ADD CONSTRAINT — mismo patrón que la migración 001 usó para agregar CUARENTENA a current_status.
  - Migración 006: DDL de cattle_breed_catalog (especie VARCHAR+CHECK, mismo patrón que species/category; sin FK a un catálogo de especies que no existe). Incluye índice único parcial para el caso raza_variante NULL (UNIQUE no detecta duplicados con NULL en Postgres) y CHECK de rango en pct_peso_primer_servicio.
  - Migración 007: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Aplicadas y verificadas en producción (incluye pruebas de los 4 CHECK/UNIQUE con inserts de violación intencional).

- Frontend: nuevo módulo features/admin/components/breed-catalog + breed-form-modal (Standalone, Signals, OnPush), replicando el patrón visual/interacción de tenant-list + upp-form-modal. AdminService extendido con el CRUD del catálogo. Ruta /admin/razas y entrada de sidebar protegidas por roleGuard(['ADMIN']).

- .gitignore: la regla *.sql (pensada para dumps/backups) estaba silenciando también database/migrations/ — nunca se había versionado ni el historial previo (001-004). Se agrega excepción explícita y se incorporan las 7 migraciones a git.



* feat(agro-erp/admin): add lifestage catalog (Fase 1)

Fase 1 de Etapas de Vida / Protocolo Sanitario: catálogo GLOBAL (sin tenant_id) de transiciones de categoría por especie (ej. Becerra → Novillona → Vaca), administrable exclusivamente por ADMIN. Depende de cattle_breed_catalog (Fase 0) y del CHECK de category con NOVILLONA, ambos validados contra el clon local antes de tocar código. No implementa todavía ninguna lógica que dispare o valide transiciones reales contra cattle_livestock (Protocolo Sanitario, fase futura separada) ni toca el pipeline del Agente IA / Meta-CRUD más allá del registro estándar en crud_models.

- DB (validado contra clon local, aplicado y verificado en producción):
  - Migración 008: DDL de cattle_lifestage_catalog. categoria_origen/ categoria_destino llevan CHECK contra los 12 valores reales del enum category (mismo patrón que especie en cattle_breed_catalog, evita typos), más CHECK de no-auto-transición y edad_min_meses > 0. Incluye las 4 filas semilla BOVINO confirmadas por el cliente (Búfalo/Borrego quedan pendientes de confirmación, sin filas placeholder).
  - Migración 009: registro en crud_models (ADMIN exclusivo en las 4 operaciones — catálogo de configuración, no dato operativo).
  - Verificadas las 4 CHECK/UNIQUE con inserts de violación intencional (categoría inválida, auto-transición, edad ≤ 0, duplicado).

- Frontend: nuevo módulo features/admin/components/lifestage-catalog + lifestage-form-modal (Standalone, Signals, OnPush), replicando exactamente el patrón visual/interacción de breed-catalog (Fase 0). AdminService extendido con el CRUD del catálogo. Ruta /admin/etapas-vida y entrada de sidebar protegidas por roleGuard(['ADMIN']).



* fix(agro): repair companys sequence before seeding new tenants

* fix(agro): expose created_at in compliance views (Meta-CRUD contract)

* fix(agro): grant tenant access for UPP companies created in migration 019

* docs(agro): add compliance frontend brief and domain models

* feat(agro): add compliance module frontend (UPP/PSG, read-only) El registro normativo SENASICA-SINIIGA está en producción (migraciones 010-022) pero sin superficie visible en el frontend: 2 de las 3 UPP del cliente llevan más de un año sin reactualizarse (662 y 537 días) y hoy no hay forma de detectarlo desde la UI. Este módulo consume los 4 modelos de solo lectura ya expuestos vía Meta-CRUD; no toca base de datos ni crud_models, ni implementa alta/edición/carga de documentos.

- Servicio (features/compliance/services/compliance.service.ts): replica el patrón "MetaCRUD Silent Error Shield" ya vigente en cattle-api.service.ts (inspecciona response.error en HTTP 200, no solo el status). Parsea explícitamente los numéricos que la API entrega como string (total_surface_ha, grazing_surface_ha, active_head_in_system) y expone un flag hasGrazingSurface derivado en el mapeo, ya que la API responde "0.00" tanto para superficie de pastoreo no declarada como para un cero real — un consumidor futuro ya no depende de recordarlo. loadUppStatus/loadPsgStatus son idempotentes (guardados por signal interno) para que la alert card del dashboard y el listado no dupliquen la petición.

- Componentes: ComplianceAlertCardComponent (embebida en main-dashboard, visible sin scroll — es el mensaje más importante de la pantalla), UppComplianceListComponent (semáforo por
  update_status, orden por criticidad: EXPIRED > WARNING > UNKNOWN >
  OK, badge de inconsistencia de superficie) y UppDetailComponent (identificación, superficie, último censo declarado, ubicación).

- Rutas lazy bajo /cumplimiento (app.routes.ts), protegidas por el authGuard ya aplicado al layout principal. Entrada de sidebar reutilizando el computed isLivestock() existente, sin lógica de dominio nueva.

- Sin localStorage/sessionStorage, sin cálculos derivados que debieran venir del servidor. ng build agro-erp --configuration=production compila sin errores ni warnings nuevos.



* fix(agro): guard against phantom rows and localize compliance status labels

The Meta-CRUD gateway returns `data: [{}]` instead of `[]` for empty collections, so every list rendered a phantom entry and reported a count of 1. Verified against cattle_breed_catalog (0 rows in the database, "1/1 razas" in the UI with a blank card).

- Add core/utils/gateway-empty-row.util.ts with stripPhantomRows/isPhantomRow, keyed on the expected primary key rather than Object.keys().length, so an object with null fields but no identifier is also discarded
- Apply the filter in ComplianceService (production_unit_id, psg_license_id, id) and in AdminService (loadBreeds, loadUsers, loadGuests, loadCompanies, loadLifestages) — loadCompanies feeds the Context Switcher
- Add empty states to the UPP list and the declared census panel
- Localize update_status and validity_status labels to Spanish in the UI; the union type values are unchanged

The util is a workaround, not a fix: the gateway itself still needs to return an empty array. Comment in the util points at the underlying bug.

* feat(agro-erp): add database migration for herd free certificates and exit rules

- Create migration 024_herd_free_certificates_and_exit_rules.sql for livestock parametrization.
- Add schema tables and constraints to track herd health free certificates (hato libre).
- Implement parametrized business rules and validation checks for livestock exit protocols.
- Ensure foreign keys and indexing are configured for audit and compliance queries.

* feat(agro): add herd-free certificates and fix livestock exit validation

The 60-day window applies to lot tests only; a unit with a current herd-free certificate is exempt. The routine also never checked for an official SINIIGA ear tag, which NOM-001-SAG/GAN-2015 requires for any movement.

- Add herd_free_certificates scoped to the production unit, one row per disease
- Add fn_has_official_ear_tag and fn_is_herd_free
- Rewrite sp_procesar_salida_ganado to check both, still as business rejections
- Add vw_livestock_movement_readiness for per-animal eligibility
- Version the REVERSION movement type applied during the 2026-07-28 incident

* fix(agro): correct UPP 54 registry data and restore truncated SINIIGA tags

* feat(agro): add brand registry, ownership and maternal lineage

* feat(agro): add equine species support; document data completeness inventory

* feat(agro): add paddocks and birth events with maternal lineage tracking

* fix(db-metadata): align crud_models with composite pk and remove phantom properties

- Update primary_key configuration to 'email, id_company' for user_companies table.
- Remove orphan 'id' key specification from users table schema_json metadata.
- Ensure strict alignment with PostgreSQL schema DDL constraints.

* docs(audit): add inventory completeness and system readiness report

- Document critical operational blockers (RFID bolo count, herd free certs, brand assignment).
- Highlight inventory discrepancies between system database and physical records (UPP 54).
- Detail domain model gaps (paddocks, calving events, ear tag lifecycle) and tech debt (DT-06, DT-09).
- Define action plan and verification SQL scripts for field audit alignment.

* docs(agro): sync CLAUDE.md, ARCHITECTURE.md and DATABASE_SCHEMA.md with v1.9.0

Documentation had not been updated since the regulatory registry work began (migrations 010-030). Three corrections matter most:

- electronic_rfid was documented as the "Primary Operational Key" with full confidence; production shows 97% of the herd (262/270) has no bolo ruminal. sp_procesar_salida_ganado keys on it, so only 8 animals can go through the official exit flow today. Flagged as a pending business decision, not fixed in code.
- Documents for the first time the Meta-CRUD gateway's three implicit runtime contracts (created_at required on every registered view, exact payload shape, empty collections returned as data:[{}] instead of []) — none were written anywhere and each cost a debugging round to discover.
- Retracts an earlier false diagnosis: a "critical allowed_fields bug" on cattle_livestock reported during design turned out not to exist in production; it came from a stale crud_models_seed.sql in the repo. Left in the record as a corrected entry rather than silently removed, since it's the operational lesson of the whole exercise.

Also documents the full Regulatory Registry Subsystem (production_units, psg_licenses, livestock_producers, brand_registrations, birth_events, production_unit_paddocks, herd_free_certificates, compliance_* tables), the corrected sp_procesar_salida_ganado rules (official tag + herd-free exemption), and the 11 new Meta-CRUD models.

* feat(agro): add leased land sites and ranch management protocols

* feat(agro): load Rancho El Triunfo adult cattle and palpation results

- 6 vacas y 17 crias nuevas + upsert de 1 semental y 12 vacas ya existentes en UPP 54
- Arete 0721391943 excluido: conflicto con NOVILLO ya existente, pendiente confirmar con cliente
- Script corregido: JSON literal roto, current_weight_kg NOT NULL, guard contra reubicar animales con production_unit_id ya asignado, exclusion real de filas con error de validacion

* feat(agro): load Ganado Rojo (201) and Pedro Tabasco batch (24)

- 201 cabezas Droughtmaster en La Bendición, 148 sin arete cargadas por quemado usando placeholder S/N-<fuego>-<fila>, mismo patron ya establecido en produccion
- Migracion 037: psg_licenses no tenia columna notes ni permitia issued_at NULL, pese a que fn_psg_validity_status ya estaba disenada para ese caso
- 24 animales de Pedro en Puyacatengo, 12 de ellos corrigen registros previos mal etiquetados como NOVILLO/VACIA -- hallazgo: el lote sospechoso de 21 detectado dias atras es en gran parte este mismo hato mal importado de origen
- rfid_siniiga es NOT NULL en produccion (no documentado); fix reutiliza el patron S/N- ya existente en vez de inventar uno nuevo

* feat(agro): alta of 3 breeding bulls via interstate transit guide (Tenosique->Palenque)

* feat(agro-erp): add cattle movement event tracking with tenant isolation

Adds cattle_movement_events and cattle_movement_event_animals as the event log for real livestock movements, complementing the existing cattle_movement_rules policy catalog (020, still unconfirmed).

- psg_facilities: models PSG as a physical destination, not just a license, per client confirmation
- external_destinations: catalog for third-party (non-tenant) destinations such as slaughterhouses and buyers
- Movement destination is exactly one of: internal production unit, internal PSG facility, or external destination (CHECK constraint)
- status column defaults to COMPLETED (today's single-party WhatsApp + photo + REEMO folio workflow); PENDING_ACK/ACKNOWLEDGED reserved for a future two-party acknowledgement flow without requiring another migration
- rule_id links to cattle_movement_rules(id) for future enforcement, nullable and unused until the policy matrix is confirmed
- Fail-closed tenant isolation via BEFORE INSERT/UPDATE triggers on both tables, since n8n_user is superuser and no RLS is in place. Verified locally and in production: cross-tenant movement is rejected, same-tenant movement succeeds.

Applied and verified against local clone and production VPS (cattle_movement_events table confirmed empty after trigger rejected the cross-tenant test insert).

* fix(security): remediate supply chain vulnerabilities across workspace and microservices

- Synchronize core Angular packages (@angular/core, @angular/common, @angular/compiler, etc.) to version 21.2.19 to patch XSS and Cache-Key ambiguity vectors.
- Implement strict resolution overrides in package.json for transitive dependencies including ip-address (^10.2.1), fast-uri (^3.1.5), dompurify (^3.4.13), undici (^6.28.0), and @hono/node-server (^2.0.12).
- Add targeted package resolution overrides for ip-address in jwt-service to eliminate SSRF and trust-boundary risks introduced via express-rate-limit.
- Purge node_modules and regenerate secure lockfiles across all scopes to guarantee zero vulnerability compliance.

* feat(agro-erp): register cattle movement tables in Meta-CRUD gateway

Registers psg_facilities, external_destinations, cattle_movement_events, and cattle_movement_event_animals in crud_models (039) so the n8n dynamic-crud-engine gateway and the Angular frontend can read/write them.

- psg_facilities, external_destinations: reference-catalog role pattern, same as production_units/psg_licenses (ADMIN,OWNER write; ADMIN,EDITOR,CUSTOMER read).
- cattle_movement_events, cattle_movement_event_animals: editable per client decision, restricted to ADMIN,OWNER for INSERT/UPDATE (not EDITOR/CUSTOMER), no DELETE op exposed. Flagged as a candidate for an append-only correction pattern instead of open UPDATE if this becomes a real workflow need, since REEMO folio is a compliance record.

Applied and verified against local clone and production VPS (ids 62-65, roles and allowed_ops confirmed via SELECT in both environments).

* feat(agro-erp): bridge external_destinations to the movement rules vocabulary

Adds normative_type to external_destinations, a compliance-facing classification matching cattle_movement_rules.destination_type (020): UPP, PSG, RASTRO, or EXPORTACION.

Rejected a hardcoded CASE mapping from destination_type (039's commercial vocabulary: THIRD_PARTY_RANCH, BUYER, SLAUGHTERHOUSE, EXPORT, OTHER) to the normative vocabulary in trigger logic, since that couples two independent domains and cannot represent destination_type values with no fixed normative equivalent (a BUYER may legally operate as a UPP, a PSG, or ship straight to RASTRO depending on the specific buyer). Delegating classification to a column keeps the eventual rule_id-matching logic a plain equality check.

Applied as NOT NULL with no backfill: external_destinations was confirmed empty in both environments before this migration.

Applied and verified against local clone and production VPS.

* feat(agro-erp): replace draft movement rules with confirmed business rules

Migration 042 replaces the 8 draft rows in cattle_movement_rules (020) with 16 rows reflecting real SENASICA/REEMO business rules confirmed by Alejandro/Pedro (audio transcript, Aug 2026):

- PSG -> UPP is now permanently disallowed (is_allowed=false, is_confirmed=true, both local and interstate) — a PSG-resident animal can never return to a UPP. The draft had this allowed by default, which was wrong.
- Requirements now depend on is_interstate, not just the origin/ destination pair: same-state UPP-UPP/UPP-PSG/PSG-PSG movements only need a transit guide; interstate movements additionally require TB/BR status (or herd-free), an OIRSA screwworm certificate, and the destination state's introduction permit.
- is_confirmed is withheld (false) on all rows except PSG->UPP, pending stakeholder sign-off on requires_destination_ack, which was asked separately and remains unanswered. Values are stored so nothing needs to be re-asked once that answer arrives.
- RASTRO/EXPORTACION rows remain unconfirmed drafts, split into interstate/local for schema consistency but not covered by the audio.

Migration 043 reverses a scope decision from 039: adds psg_facility_origin_id to cattle_movement_events (production_unit_origin_id is now nullable), since the same audio confirmed PSG-to-PSG and PSG-to-RASTRO/EXPORTACION movements originate from a PSG in practice. Mirrors the existing three-way destination exclusivity pattern (chk_origin_exclusive) and extends the tenant-isolation trigger accordingly.

Both migrations include a preflight guard (DO block) that aborts if cattle_movement_events already has data referencing what's being restructured — verified empty (0 rows) in both environments before applying.

Applied and verified against local clone and production VPS. Backup taken before production apply (pre_migracion_042_043_20260811_093113.dump).

* fix(agro-erp): sync activeTab signal with route query param for CRIA/ENGORDA toggle

Convert activeTab from a manually-written signal to a computed derived from the route queryParamMap, so the URL is the single source of truth. setTab() now only navigates; it no longer needs to write activeTab directly. Add an effect to reset activeSubTab and pagination when activeTab changes, so switching modules doesn't leave the user on a stale sub-tab or page.

Previously the toggle updated the URL (?tab=engorda) but never touched the signal feeding filteredCattleList(), biomasaTotal(), capitalizacionTotal(), etc., so both modules showed identical figures.

feat(agro-erp): improve vientres audit table with search, sort and diagnosis-status breakdown

Distinguish animals with no palpation record (last_palpation_result null/undefined) from animals diagnosed VACIA, previously both shown as the same N/A badge. Add a search input (arete/numero_fuego) and default sort by gestation days descending. Add a quick-count summary row (Sin Diagnóstico / Preñadas / Vacías) above the table.

Reuses the existing Paginator composable; no change to stats() pregnancy-rate calculation.

* fix(agro-erp): remove inline font-size overrides and fix text-dark contrast bug on page-title

Normalize page-title font-size across dashboard, cattle-list, adg-alerts, upp-compliance-list and upp-detail views (no more inline style overrides). Also remove text-dark, which hardcoded a light-theme-only color and made titles nearly unreadable in dark mode — the actual cause of titles appearing blank on screen.

---------